### PR TITLE
Fix HardFault caused by tx_thread_stack_build.s

### DIFF
--- a/ports/cortex_m3/ac5/src/tx_thread_stack_build.s
+++ b/ports/cortex_m3/ac5/src/tx_thread_stack_build.s
@@ -114,7 +114,7 @@ _tx_thread_stack_build
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1

--- a/ports/cortex_m3/iar/src/tx_thread_stack_build.s
+++ b/ports/cortex_m3/iar/src/tx_thread_stack_build.s
@@ -120,7 +120,7 @@ _tx_thread_stack_build:
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1

--- a/ports/cortex_m3/keil/src/tx_thread_stack_build.s
+++ b/ports/cortex_m3/keil/src/tx_thread_stack_build.s
@@ -119,7 +119,7 @@ _tx_thread_stack_build
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1

--- a/ports/cortex_m4/ac5/src/tx_thread_stack_build.s
+++ b/ports/cortex_m4/ac5/src/tx_thread_stack_build.s
@@ -114,7 +114,7 @@ _tx_thread_stack_build
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1

--- a/ports/cortex_m4/iar/src/tx_thread_stack_build.s
+++ b/ports/cortex_m4/iar/src/tx_thread_stack_build.s
@@ -120,7 +120,7 @@ _tx_thread_stack_build:
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1

--- a/ports/cortex_m4/keil/src/tx_thread_stack_build.s
+++ b/ports/cortex_m4/keil/src/tx_thread_stack_build.s
@@ -119,7 +119,7 @@ _tx_thread_stack_build
     STR     r3, [r2, #28]                           ; Store initial r10
     STR     r3, [r2, #32]                           ; Store initial r11
 ;
-;    /* Hardware stack follows.  /
+;    /* Hardware stack follows.  */
 ;
     STR     r3, [r2, #36]                           ; Store initial r0
     STR     r3, [r2, #40]                           ; Store initial r1


### PR DESCRIPTION
I suffered HardFault in `tx-scheduler` based on Keil toolchain.
The root cause is in `tx_thread_stack_build.s`, the object code lost some instructions and not push `r0-r3, r12, lr& pc` into stack.
This symptom is relative to `--cpreproc` in Assembler compile option.( i.e: This option is for assembly file including header file `xxx.h`) .

After complete the bracket of ASM comment of `tx_thread_stack_build.s`, it's fixed.
