### PR TITLE
New port files for Cortex-M (C source, 

### DIFF
--- a/ports/cortex_m_cmsis/example_build/tx_cmsis_sample.h
+++ b/ports/cortex_m_cmsis/example_build/tx_cmsis_sample.h
@@ -1,0 +1,29 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   CMSIS                                                               */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#ifndef TX_CMSIS_H
+#define TX_CMSIS_H
+
+/* Include CMSIS header file here, typically "<part_number>.h". */
+/* #include "R7FA6M4AF.h" */
+
+#endif                                 /* TX_CMSIS_H */

--- a/ports/cortex_m_cmsis/example_build/tx_initialize_low_level_sample.c
+++ b/ports/cortex_m_cmsis/example_build/tx_initialize_low_level_sample.c
@@ -1,0 +1,124 @@
+/**************************************************************************/
+
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Initialize                                                          */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_initialize.h"
+#include "tx_thread.h"
+#include "tx_timer.h"
+
+/* SysTick must not be higher priority (lower numerical value) than maximum
+ * ThreadX interrupt priority. */
+
+#if TX_PORT_CFG_SYSTICK_IPL < TX_PORT_MAX_IPL
+ #undef TX_PORT_CFG_SYSTICK_IPL
+ #define TX_PORT_CFG_SYSTICK_IPL    TX_PORT_MAX_IPL
+#endif
+
+/* Define the location of the begining of the free RAM  */
+
+#if defined(__ARMCC_VERSION)           /* AC6 compiler */
+extern uint32_t Image$$RAM_END$$Limit;
+ #define TX_FREE_MEMORY_START    &Image$$RAM_END$$Limit
+#elif   defined(__GNUC__)              /* GCC compiler */
+extern void * __RAM_segment_used_end__;
+ #define TX_FREE_MEMORY_START    (&__RAM_segment_used_end__)
+#elif defined(__ICCARM__)              /* IAR compiler */
+extern void * __tx_free_memory_start;
+ #define TX_FREE_MEMORY_START    (&__tx_free_memory_start)
+
+/* __tx_free_memory_start must be placed at the end of RAM in section FREE_MEM. */
+ #pragma section="FREE_MEM"
+__root void * __tx_free_memory_start @"FREE_MEM";
+#endif
+
+extern void * __Vectors[];
+#define TX_VECTOR_TABLE    __Vectors
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_initialize_low_level                          Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for any low-level processor            */
+/*    initialization, including setting up interrupt vectors, setting     */
+/*    up a periodic timer interrupt source, saving the system stack       */
+/*    pointer for use in ISR processing later, and finding the first      */
+/*    available RAM memory address for tx_application_define.             */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    _tx_initialize_kernel_enter           ThreadX entry function        */
+/*                                                                        */
+/**************************************************************************/
+
+VOID _tx_initialize_low_level (VOID)
+{
+    /* Ensure that interrupts are disabled.  */
+#ifdef TX_PORT_USE_BASEPRI
+    __set_BASEPRI(TX_PORT_MAX_IPL << (8U - __NVIC_PRIO_BITS));
+#else
+    __disable_irq();
+#endif
+
+    /* Set base of available memory to end of non-initialized RAM area.  */
+    _tx_initialize_unused_memory = TX_UCHAR_POINTER_ADD(TX_FREE_MEMORY_START, 4);
+
+    /* Set system stack pointer from vector value.  */
+    _tx_thread_system_stack_ptr = TX_VECTOR_TABLE[0];
+
+#if defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
+
+    /* Enable the cycle count register.  */
+    DWT->CTRL |= (uint32_t) DWT_CTRL_CYCCNTENA_Msk;
+#endif
+
+#ifndef TX_NO_TIMER
+
+    /* Configure SysTick based on user configuration (100 Hz by default).  */
+    extern uint32_t SystemCoreClock;
+    SysTick_Config(SystemCoreClock / TX_TIMER_TICKS_PER_SECOND);
+    NVIC_SetPriority(SysTick_IRQn, TX_PORT_CFG_SYSTICK_IPL); // Set User configured Priority for Systick Interrupt
+#endif
+
+    /* Configure the handler priorities. */
+    NVIC_SetPriority(SVCall_IRQn, UINT8_MAX);                // Note: SVC must be lowest priority, which is 0xFF
+    NVIC_SetPriority(PendSV_IRQn, UINT8_MAX);                // Note: PnSV must be lowest priority, which is 0xFF
+}

--- a/ports/cortex_m_cmsis/example_build/tx_port_vendor_sample.h
+++ b/ports/cortex_m_cmsis/example_build/tx_port_vendor_sample.h
@@ -1,0 +1,48 @@
+/**************************************************************************/
+
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Port Specific                                                       */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+/**************************************************************************/
+/*                                                                        */
+/*  PORT SPECIFIC C INFORMATION                            RELEASE        */
+/*                                                                        */
+/*    tx_port_vendor_sample.h                           Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This file contains vendor specific customizations of the            */
+/*    Cortex-M/CMSIS port.                                                */
+/*                                                                        */
+/**************************************************************************/
+
+/* If the MCU supports PSPLIM, define TX_PORT_PSPLIM_PRESENT. */
+/* #define TX_PORT_PSPLIM_PRESENT */
+
+/* If a vendor specific stack monitor is used, define the following:
+ *   - TX_PORT_VENDOR_STACK_MONITOR_ENABLE
+ *   - TX_PORT_VENDOR_ASM_STACK_MONITOR_CONFIGURE (new thread pointer is in r6)
+ *   - TX_PORT_VENDOR_ASM_STACK_MONITOR_ENABLE
+ */
+/* #define TX_PORT_VENDOR_STACK_MONITOR_ENABLE */
+
+/* Prototype of function that can be overridden to handle low power control
+ * in idle processing. */
+void * _tx_port_wait_thread_ready(void);

--- a/ports/cortex_m_cmsis/inc/tx_port.h
+++ b/ports/cortex_m_cmsis/inc/tx_port.h
@@ -1,0 +1,676 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Port Specific                                                       */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  PORT SPECIFIC C INFORMATION                            RELEASE        */
+/*                                                                        */
+/*    tx_port.h                                         Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This file contains data type definitions that make the ThreadX      */
+/*    real-time kernel function identically on a variety of different     */
+/*    processor architectures.  For example, the size or number of bits   */
+/*    in an "int" data type vary between microprocessor architectures and */
+/*    even C compilers for the same microprocessor.  ThreadX does not     */
+/*    directly use native C data types.  Instead, ThreadX creates its     */
+/*    own special types that can be mapped to actual data types by this   */
+/*    file to guarantee consistency in the interface and functionality.   */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef TX_PORT_H
+#define TX_PORT_H
+
+#include "tx_port_vendor.h"
+
+/* Determine if the optional ThreadX user define file should be used.  */
+#ifdef TX_INCLUDE_USER_DEFINE_FILE
+
+/* Yes, include the user defines in tx_user.h. The defines in this file may 
+   alternately be defined on the command line.  */
+
+#include "tx_user.h"
+#endif
+
+/* Define compiler library include files.  */
+
+#include <stdlib.h>
+#include <string.h>
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#include <yvals.h>
+#endif
+
+/* CMSIS Core access. */
+
+#include "tx_cmsis.h"
+
+/* Determine non-secure callable functions can be accessed in threads.  */
+
+#if defined(__ARM_FEATURE_CMSE) && !defined(TX_SINGLE_MODE_SECURE) && !defined(TX_SINGLE_MODE_NON_SECURE)
+#define TX_PORT_TRUSTZONE_NSC_ENABLE
+#endif
+
+/* If non-secure callable functions can be accessed in threads, include the CMSIS TrustZone secure context header.  */
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+#include "tz_context.h"
+#endif
+
+/* Define ThreadX basic types for this port.  */
+
+#define VOID                                    void
+typedef char                                    CHAR;
+typedef unsigned char                           UCHAR;
+typedef int                                     INT;
+typedef unsigned int                            UINT;
+typedef long                                    LONG;
+typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
+typedef short                                   SHORT;
+typedef unsigned short                          USHORT;
+
+#if defined(TX_PORT_TRUSTZONE_NSC_ENABLE)
+
+/* Function prototypes for this port. */
+struct  TX_THREAD_STRUCT;
+UINT    _txe_thread_secure_stack_allocate(struct TX_THREAD_STRUCT *thread_ptr, ULONG stack_size);
+UINT    _txe_thread_secure_stack_free(struct TX_THREAD_STRUCT *thread_ptr);
+UINT    _tx_thread_secure_stack_allocate(struct TX_THREAD_STRUCT *thread_ptr, ULONG stack_size);
+UINT    _tx_thread_secure_stack_free(struct TX_THREAD_STRUCT *thread_ptr);
+
+/* Define the system API mappings based on the error checking 
+   selected by the user.  Note: this section is only applicable to 
+   application source code, hence the conditional that turns off this
+   stuff when the include file is processed by the ThreadX source. */
+
+#ifndef TX_SOURCE_CODE
+
+
+/* Determine if error checking is desired.  If so, map API functions 
+   to the appropriate error checking front-ends.  Otherwise, map API
+   functions to the core functions that actually perform the work. 
+   Note: error checking is enabled by default.  */
+
+#ifdef TX_DISABLE_ERROR_CHECKING
+
+/* Services without error checking.  */
+
+#define tx_thread_secure_stack_allocate   _tx_thread_secure_stack_allocate
+#define tx_thread_secure_stack_free       _tx_thread_secure_stack_free
+
+#else
+
+/* Services with error checking.  */
+
+#define tx_thread_secure_stack_allocate   _txe_thread_secure_stack_allocate
+#define tx_thread_secure_stack_free       _txe_thread_secure_stack_free
+
+#endif
+#endif
+
+#endif
+
+
+/* Define the priority levels for ThreadX.  Legal values range
+   from 32 to 1024 and MUST be evenly divisible by 32.  */
+
+#ifndef TX_MAX_PRIORITIES
+#define TX_MAX_PRIORITIES                       32
+#endif
+
+
+/* Define the minimum stack for a ThreadX thread on this processor. If the size supplied during
+   thread creation is less than this value, the thread create call will return an error.  */
+
+#ifndef TX_MINIMUM_STACK
+#define TX_MINIMUM_STACK                        200         /* Minimum stack size for this port  */
+#endif
+
+
+/* Define the system timer thread's default stack size and priority.  These are only applicable
+   if TX_TIMER_PROCESS_IN_ISR is not defined.  */
+
+#ifndef TX_TIMER_THREAD_STACK_SIZE
+#define TX_TIMER_THREAD_STACK_SIZE              1024        /* Default timer thread stack size  */
+#endif
+
+#ifndef TX_TIMER_THREAD_PRIORITY    
+#define TX_TIMER_THREAD_PRIORITY                0           /* Default timer thread priority    */
+#endif
+
+
+/* Define various constants for the ThreadX Cortex-M port.  */
+
+#define TX_INT_DISABLE                          1           /* Disable interrupts               */
+#define TX_INT_ENABLE                           0           /* Enable interrupts                */
+
+
+/* Define the clock source for trace event entry time stamp. The following two item are port specific.
+   For example, if the time source is at the address 0x0a800024 and is 16-bits in size, the clock 
+   source constants would be:
+
+#define TX_TRACE_TIME_SOURCE                    *((ULONG *) 0x0a800024)
+#define TX_TRACE_TIME_MASK                      0x0000FFFFUL
+
+*/
+
+#ifndef TX_MISRA_ENABLE
+#ifndef TX_TRACE_TIME_SOURCE
+#if defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
+/* CM4 and CM33 do have DWT. */
+#define TX_TRACE_TIME_SOURCE                    *((ULONG *) 0xE0001004)
+#else
+/* CM23 does not have DWT. */
+#define TX_TRACE_TIME_SOURCE                    ++_tx_trace_simulated_time
+#endif
+#endif
+#else
+ULONG   _tx_misra_time_stamp_get(VOID);
+#define TX_TRACE_TIME_SOURCE                    _tx_misra_time_stamp_get()
+#endif
+
+#ifndef TX_TRACE_TIME_MASK
+#define TX_TRACE_TIME_MASK                      0xFFFFFFFFUL
+#endif
+
+
+/* Define the port specific options for the _tx_build_options variable. This variable indicates
+   how the ThreadX library was built.  */
+
+#define TX_PORT_SPECIFIC_BUILD_OPTIONS          (0)
+
+
+/* Define the in-line initialization constant so that modules with in-line
+   initialization capabilities can prevent their initialization from being
+   a function call.  */
+
+#ifdef TX_MISRA_ENABLE
+#define TX_DISABLE_INLINE
+#else
+#define TX_INLINE_INITIALIZATION
+#endif
+
+
+/* Determine whether or not stack checking is enabled. By default, ThreadX stack checking is 
+   disabled. When the following is defined, ThreadX thread stack checking is enabled.  If stack
+   checking is enabled (TX_ENABLE_STACK_CHECKING is defined), the TX_DISABLE_STACK_FILLING
+   define is negated, thereby forcing the stack fill which is necessary for the stack checking
+   logic.  */
+
+#ifndef TX_MISRA_ENABLE
+#ifdef TX_ENABLE_STACK_CHECKING
+#undef TX_DISABLE_STACK_FILLING
+#endif
+#endif
+
+
+/* Define the TX_THREAD control block extensions for this port. The main reason
+   for the multiple macros is so that backward compatibility can be maintained with 
+   existing ThreadX kernel awareness modules.  */
+
+#ifndef TX_THREAD_EXTENSION_0
+#define TX_THREAD_EXTENSION_0       
+#endif
+
+#ifndef TX_THREAD_EXTENSION_1
+#define TX_THREAD_EXTENSION_1
+#endif
+
+#ifndef TX_THREAD_EXTENSION_2
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+/* IAR library support */
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+/* ThreadX in non-secure zone with calls to secure zone. */
+#define TX_THREAD_EXTENSION_2           TZ_MemoryId_t tx_thread_secure_stack_context;    \
+                                        VOID          *tx_thread_iar_tls_pointer;
+#else
+/* ThreadX in only one zone. */
+#define TX_THREAD_EXTENSION_2           VOID          *tx_thread_iar_tls_pointer;
+#endif
+
+#else
+/* No IAR library support */
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+/* ThreadX in non-secure zone with calls to secure zone. */
+#define TX_THREAD_EXTENSION_2           TZ_MemoryId_t tx_thread_secure_stack_context;
+#else
+/* ThreadX in only one zone. */
+#define TX_THREAD_EXTENSION_2
+#endif
+#endif
+#endif
+
+#ifndef TX_THREAD_EXTENSION_3
+#ifndef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+#define TX_THREAD_EXTENSION_3
+#else
+#define TX_THREAD_EXTENSION_3           unsigned long long  tx_thread_execution_time_total; \
+                                        unsigned long long  tx_thread_execution_time_last_start; 
+#endif
+#endif
+
+/* Define the port extensions of the remaining ThreadX objects.  */
+
+#ifndef TX_BLOCK_POOL_EXTENSION
+#define TX_BLOCK_POOL_EXTENSION
+#endif
+#ifndef TX_BYTE_POOL_EXTENSION
+#define TX_BYTE_POOL_EXTENSION
+#endif
+#ifndef TX_EVENT_FLAGS_GROUP_EXTENSION
+#define TX_EVENT_FLAGS_GROUP_EXTENSION
+#endif
+#ifndef TX_MUTEX_EXTENSION
+#define TX_MUTEX_EXTENSION
+#endif
+#ifndef TX_QUEUE_EXTENSION
+#define TX_QUEUE_EXTENSION
+#endif
+#ifndef TX_SEMAPHORE_EXTENSION
+#define TX_SEMAPHORE_EXTENSION
+#endif
+#ifndef TX_TIMER_EXTENSION
+#define TX_TIMER_EXTENSION
+#endif
+
+
+/* Define the user extension field of the thread control block.  Nothing 
+   additional is needed for this port so it is defined as white space.  */
+
+#ifndef TX_THREAD_USER_EXTENSION
+#define TX_THREAD_USER_EXTENSION
+#endif
+
+
+/* Define the macros for processing extensions in tx_thread_create, tx_thread_delete,
+   tx_thread_shell_entry, and tx_thread_terminate.  */
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+void    *_tx_iar_create_per_thread_tls_area(void);
+void    _tx_iar_destroy_per_thread_tls_area(void *tls_ptr);
+void    __iar_Initlocks(void);
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)                      thread_ptr -> tx_thread_iar_tls_pointer =  _tx_iar_create_per_thread_tls_area();
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                      do {_tx_iar_destroy_per_thread_tls_area(thread_ptr -> tx_thread_iar_tls_pointer);   \
+                                                                        thread_ptr -> tx_thread_iar_tls_pointer =  TX_NULL; } while(0);                 \
+                                                                    if(thread_ptr -> tx_thread_secure_stack_context){_tx_thread_secure_stack_free(thread_ptr);}
+#else
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                      do {_tx_iar_destroy_per_thread_tls_area(thread_ptr -> tx_thread_iar_tls_pointer);   \
+                                                                        thread_ptr -> tx_thread_iar_tls_pointer =  TX_NULL; } while(0);
+#endif
+#define TX_PORT_SPECIFIC_PRE_SCHEDULER_INITIALIZATION               do {__iar_Initlocks();} while(0);
+#else
+/* No IAR library support. */
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)  
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                      if(thread_ptr -> tx_thread_secure_stack_context){_tx_thread_secure_stack_free(thread_ptr);}
+#else
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)
+#endif
+#endif
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+/* Define the size of the secure stack for the timer thread and use the extension to allocate the secure stack. */
+#define TX_TIMER_THREAD_SECURE_STACK_SIZE   256
+#define TX_TIMER_INITIALIZE_EXTENSION(status)   _tx_thread_secure_stack_allocate(&_tx_timer_thread, TX_TIMER_THREAD_SECURE_STACK_SIZE);
+#endif
+
+#if __FPU_USED
+
+#ifdef TX_MISRA_ENABLE
+
+ULONG  _tx_misra_control_get(void);
+void   _tx_misra_control_set(ULONG value);
+ULONG  _tx_misra_fpccr_get(void);
+void   _tx_misra_vfp_touch(void);
+
+#endif
+
+/* A completed thread falls into _thread_shell_entry and we can simply deactivate the FPU via CONTROL.FPCA
+   in order to ensure no lazy stacking will occur. */
+
+#ifndef TX_MISRA_ENABLE
+
+#define TX_THREAD_COMPLETED_EXTENSION(thread_ptr)                   {                                                                                             \
+                                                                    ULONG  _tx_vfp_state;                                                                         \
+                                                                        _tx_vfp_state =  __get_CONTROL();                                                         \
+                                                                        _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                                          \
+                                                                        __set_CONTROL(_tx_vfp_state);                                                             \
+                                                                    }
+#else
+
+#define TX_THREAD_COMPLETED_EXTENSION(thread_ptr)                   {                                                                                             \
+                                                                    ULONG  _tx_vfp_state;                                                                         \
+                                                                        _tx_vfp_state =  _tx_misra_control_get();                                                 \
+                                                                        _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                                          \
+                                                                        _tx_misra_control_set(_tx_vfp_state);                                                     \
+                                                                    }
+                                                                    
+#endif
+
+/* A thread can be terminated by another thread, so we first check if it's self-terminating and not in an ISR.
+   If so, deactivate the FPU via CONTROL.FPCA. Otherwise we are in an interrupt or another thread is terminating
+   this one, so if the FPCCR.LSPACT bit is set, we need to save the CONTROL.FPCA state, touch the FPU to flush 
+   the lazy FPU save, then restore the CONTROL.FPCA state. */
+
+#ifndef TX_MISRA_ENABLE
+
+#define TX_THREAD_TERMINATED_EXTENSION(thread_ptr)                  {                                                                                             \
+                                                                    ULONG  _tx_system_state;                                                                      \
+                                                                        _tx_system_state =  TX_THREAD_GET_SYSTEM_STATE();                                         \
+                                                                        if ((_tx_system_state == ((ULONG) 0)) && ((thread_ptr) == _tx_thread_current_ptr))        \
+                                                                        {                                                                                         \
+                                                                        ULONG  _tx_vfp_state;                                                                     \
+                                                                            _tx_vfp_state =  __get_CONTROL();                                                     \
+                                                                            _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                                      \
+                                                                            __set_CONTROL(_tx_vfp_state);                                                         \
+                                                                        }                                                                                         \
+                                                                        else                                                                                      \
+                                                                        {                                                                                         \
+                                                                        ULONG  _tx_fpccr;                                                                         \
+                                                                            _tx_fpccr =  *((ULONG *) 0xE000EF34);                                                 \
+                                                                            _tx_fpccr =  _tx_fpccr & ((ULONG) 0x01);                                              \
+                                                                            if (_tx_fpccr == ((ULONG) 0x01))                                                      \
+                                                                            {                                                                                     \
+                                                                            ULONG _tx_vfp_state;                                                                  \
+                                                                                _tx_vfp_state = __get_CONTROL();                                                  \
+                                                                                _tx_vfp_state =  _tx_vfp_state & ((ULONG) 0x4);                                   \
+                                                                                __asm volatile ("vmov.f32 s0, s0");                                               \
+                                                                                if (_tx_vfp_state == ((ULONG) 0))                                                 \
+                                                                                {                                                                                 \
+                                                                                    _tx_vfp_state =  __get_CONTROL();                                             \
+                                                                                    _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                              \
+                                                                                    __set_CONTROL(_tx_vfp_state);                                                 \
+                                                                                }                                                                                 \
+                                                                            }                                                                                     \
+                                                                        }                                                                                         \
+                                                                    }
+#else
+
+#define TX_THREAD_TERMINATED_EXTENSION(thread_ptr)                  {                                                                                             \
+                                                                    ULONG  _tx_system_state;                                                                      \
+                                                                        _tx_system_state =  TX_THREAD_GET_SYSTEM_STATE();                                         \
+                                                                        if ((_tx_system_state == ((ULONG) 0)) && ((thread_ptr) == _tx_thread_current_ptr))        \
+                                                                        {                                                                                         \
+                                                                        ULONG  _tx_vfp_state;                                                                     \
+                                                                            _tx_vfp_state =  _tx_misra_control_get();                                             \
+                                                                            _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                                      \
+                                                                            _tx_misra_control_set(_tx_vfp_state);                                                 \
+                                                                        }                                                                                         \
+                                                                        else                                                                                      \
+                                                                        {                                                                                         \
+                                                                        ULONG  _tx_fpccr;                                                                         \
+                                                                            _tx_fpccr =  _tx_misra_fpccr_get();                                                   \
+                                                                            _tx_fpccr =  _tx_fpccr & ((ULONG) 0x01);                                              \
+                                                                            if (_tx_fpccr == ((ULONG) 0x01))                                                      \
+                                                                            {                                                                                     \
+                                                                            ULONG _tx_vfp_state;                                                                  \
+                                                                                _tx_vfp_state = _tx_misra_control_get();                                          \
+                                                                                _tx_vfp_state =  _tx_vfp_state & ((ULONG) 0x4);                                   \
+                                                                                _tx_misra_vfp_touch();                                                            \
+                                                                                if (_tx_vfp_state == ((ULONG) 0))                                                 \
+                                                                                {                                                                                 \
+                                                                                    _tx_vfp_state =  _tx_misra_control_get();                                     \
+                                                                                    _tx_vfp_state =  _tx_vfp_state & ~((ULONG) 0x4);                              \
+                                                                                    _tx_misra_control_set(_tx_vfp_state);                                         \
+                                                                                }                                                                                 \
+                                                                            }                                                                                     \
+                                                                        }                                                                                         \
+                                                                    }
+#endif
+
+#else
+
+#define TX_THREAD_COMPLETED_EXTENSION(thread_ptr)
+#define TX_THREAD_TERMINATED_EXTENSION(thread_ptr)
+
+#endif
+
+
+/* Define the ThreadX object creation extensions for the remaining objects.  */
+
+#ifndef TX_BLOCK_POOL_CREATE_EXTENSION
+#define TX_BLOCK_POOL_CREATE_EXTENSION(pool_ptr)
+#endif
+#ifndef TX_BYTE_POOL_CREATE_EXTENSION
+#define TX_BYTE_POOL_CREATE_EXTENSION(pool_ptr)
+#endif
+#ifndef TX_EVENT_FLAGS_GROUP_CREATE_EXTENSION
+#define TX_EVENT_FLAGS_GROUP_CREATE_EXTENSION(group_ptr)
+#endif
+#ifndef TX_MUTEX_CREATE_EXTENSION
+#define TX_MUTEX_CREATE_EXTENSION(mutex_ptr)
+#endif
+#ifndef TX_QUEUE_CREATE_EXTENSION
+#define TX_QUEUE_CREATE_EXTENSION(queue_ptr)
+#endif
+#ifndef TX_SEMAPHORE_CREATE_EXTENSION
+#define TX_SEMAPHORE_CREATE_EXTENSION(semaphore_ptr)
+#endif
+#ifndef TX_TIMER_CREATE_EXTENSION
+#define TX_TIMER_CREATE_EXTENSION(timer_ptr)
+#endif
+
+
+/* Define the ThreadX object deletion extensions for the remaining objects.  */
+
+#ifndef TX_BLOCK_POOL_DELETE_EXTENSION
+#define TX_BLOCK_POOL_DELETE_EXTENSION(pool_ptr)
+#endif
+#ifndef TX_BYTE_POOL_DELETE_EXTENSION
+#define TX_BYTE_POOL_DELETE_EXTENSION(pool_ptr)
+#endif
+#ifndef TX_EVENT_FLAGS_GROUP_DELETE_EXTENSION
+#define TX_EVENT_FLAGS_GROUP_DELETE_EXTENSION(group_ptr)
+#endif
+#ifndef TX_MUTEX_DELETE_EXTENSION
+#define TX_MUTEX_DELETE_EXTENSION(mutex_ptr)
+#endif
+#ifndef TX_QUEUE_DELETE_EXTENSION
+#define TX_QUEUE_DELETE_EXTENSION(queue_ptr)
+#endif
+#ifndef TX_SEMAPHORE_DELETE_EXTENSION
+#define TX_SEMAPHORE_DELETE_EXTENSION(semaphore_ptr)
+#endif
+#ifndef TX_TIMER_DELETE_EXTENSION
+#define TX_TIMER_DELETE_EXTENSION(timer_ptr)
+#endif
+
+
+/* Define the get system state macro.   */
+   
+#ifndef TX_THREAD_GET_SYSTEM_STATE
+#ifndef TX_MISRA_ENABLE
+#define TX_THREAD_GET_SYSTEM_STATE()        (_tx_thread_system_state | __get_IPSR())
+#else
+ULONG   _tx_misra_ipsr_get(VOID);
+#define TX_THREAD_GET_SYSTEM_STATE()        (_tx_thread_system_state | _tx_misra_ipsr_get())
+#endif
+#endif
+
+
+/* Define the check for whether or not to call the _tx_thread_system_return function.  A non-zero value
+   indicates that _tx_thread_system_return should not be called. This overrides the definition in tx_thread.h
+   for Cortex-M since so we don't waste time checking the _tx_thread_system_state variable that is always
+   zero after initialization for Cortex-M ports. */
+
+#ifndef TX_THREAD_SYSTEM_RETURN_CHECK
+#define TX_THREAD_SYSTEM_RETURN_CHECK(c)    (c) = ((ULONG) _tx_thread_preempt_disable);
+#endif
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+/* Initialize secure stacks for threads calling secure functions. */
+extern void    _tx_thread_secure_stack_initialize(void);
+#define TX_PORT_SPECIFIC_PRE_INITIALIZATION     _tx_thread_secure_stack_initialize();
+#endif
+
+/* Define the macro to ensure _tx_thread_preempt_disable is set early in initialization in order to 
+   prevent early scheduling on Cortex-M parts.  */
+   
+#define TX_PORT_SPECIFIC_POST_INITIALIZATION    _tx_thread_preempt_disable++;
+
+
+/* Determine if the ARM architecture has the CLZ instruction. This is available on 
+   architectures v5 and above. If available, redefine the macro for calculating the 
+   lowest bit set.  */
+
+#ifndef TX_DISABLE_INLINE
+
+#define TX_LOWEST_SET_BIT_CALCULATE(m, b)       (b) = (UINT)__CLZ(__RBIT((m)));
+
+#endif
+
+#ifndef TX_PORT_MAX_IPL
+#define TX_PORT_MAX_IPL                              (0)
+#endif
+
+/* Cortex-M4 and Cortex-M33 have BASEPRI, so BASEPRI can be used to allow high priority interrupts
+ * to preempt the scheduler. */
+
+#if (defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)) && TX_PORT_MAX_IPL != 0
+#define TX_PORT_USE_BASEPRI
+#endif
+
+
+/* Define ThreadX interrupt lockout and restore macros for protection on 
+   access of critical kernel information.  The restore interrupt macro must 
+   restore the interrupt posture of the running thread prior to the value 
+   present prior to the disable macro.  In most cases, the save area macro
+   is used to define a local function save area for the disable and restore
+   macros.  */
+
+/* The embedded assembler blocks are design so as to be inlinable by the
+   armlink linker inlining. This requires them to consist of either a
+   single 32-bit instruction, or either one or two 16-bit instructions
+   followed by a "BX lr". Note that to reduce the critical region size, the
+   16-bit "CPSID i" instruction is preceeded by a 16-bit NOP */
+
+
+#ifdef TX_DISABLE_INLINE
+
+UINT   _tx_thread_interrupt_disable(VOID);
+VOID   _tx_thread_interrupt_restore(UINT new_posture);
+
+#define TX_INTERRUPT_SAVE_AREA  unsigned int interrupt_save;
+
+#define TX_DISABLE                              interrupt_save = _tx_thread_interrupt_disable();
+#define TX_RESTORE                              _tx_thread_interrupt_restore(interrupt_save);
+
+#else
+
+#define TX_INTERRUPT_SAVE_AREA  unsigned int interrupt_save;
+
+#ifdef TX_PORT_USE_BASEPRI
+
+#define TX_DISABLE                              interrupt_save =  __get_BASEPRI(); \
+                                                __set_BASEPRI(TX_PORT_MAX_IPL << (8U - __NVIC_PRIO_BITS));
+#define TX_RESTORE                              __set_BASEPRI(interrupt_save);
+
+/* Do not use R0 and R1 because they are used for arguments. */
+#define TX_ENABLE_ASM                           "MRS R3, BASEPRI \n" \
+                                                "MOV R2, #0      \n" \
+                                                "MSR BASEPRI, R2 \n"
+#define TX_RESTORE_ASM                          "MSR BASEPRI, R3 \n"
+
+#else
+
+/* Cortex-M23 does not have BASEPRI, so PRIMASK is used to save the interrupt state for 
+ * critical sections. */
+
+#define TX_DISABLE                              interrupt_save =  __get_PRIMASK(); \
+                                                __disable_irq();
+#define TX_RESTORE                              __set_PRIMASK(interrupt_save);
+
+/* Do not use R0 and R1 because they are used for arguments. */
+#define TX_ENABLE_ASM                           "MRS R3, PRIMASK \n" \
+                                                "CPSIE i \n"
+#define TX_RESTORE_ASM                          "MSR PRIMASK, R3 \n"
+
+#endif
+
+/* Redefine _tx_thread_system_return for improved performance.  */
+
+#define _tx_thread_system_return                _tx_thread_system_return_inline
+
+static inline void _tx_thread_system_return_inline(void)
+{
+    /* Return to real scheduler via PendSV. Note that this routine is often
+     * replaced with in-line assembly in tx_port.h to improved performance.  */
+
+    /* Set PENDSVBIT in ICSR */
+    SCB->ICSR = (uint32_t) SCB_ICSR_PENDSVSET_Msk;
+
+    /* If a thread is returning, briefly enable and restore interrupts. */
+    if (__get_IPSR() == 0)
+    {
+        UINT interrupt_save;
+#ifdef TX_PORT_USE_BASEPRI
+        interrupt_save = __get_BASEPRI();
+        __set_BASEPRI(0U);
+        __set_BASEPRI(interrupt_save);
+#else
+        interrupt_save = __get_PRIMASK();
+        __enable_irq();
+        __set_PRIMASK(interrupt_save);
+#endif
+    }
+}
+
+#endif
+
+
+/* Define the interrupt lockout macros for each ThreadX object.  */
+
+#define TX_BLOCK_POOL_DISABLE                   TX_DISABLE
+#define TX_BYTE_POOL_DISABLE                    TX_DISABLE
+#define TX_EVENT_FLAGS_GROUP_DISABLE            TX_DISABLE
+#define TX_MUTEX_DISABLE                        TX_DISABLE
+#define TX_QUEUE_DISABLE                        TX_DISABLE
+#define TX_SEMAPHORE_DISABLE                    TX_DISABLE
+
+
+/* Define prototypes specific to the ThreadX Cortex-M implementation.  */
+
+VOID  tx_isr_start(ULONG isr_id);
+VOID  tx_isr_end(ULONG isr_id);
+
+/* Define the version ID of ThreadX.  This may be utilized by the application.  */
+
+#ifdef TX_THREAD_INIT
+CHAR                            _tx_version_id[] = 
+                                    "Copyright (c) Microsoft Corporation. All rights reserved.  *  ThreadX Cortex-M/CMSIS  *";
+#else
+#ifdef TX_MISRA_ENABLE
+extern  CHAR                    _tx_version_id[100];
+#else
+extern  CHAR                    _tx_version_id[];
+#endif
+#endif
+
+
+#endif
+
+
+

--- a/ports/cortex_m_cmsis/inc/tx_secure_interface.h
+++ b/ports/cortex_m_cmsis/inc/tx_secure_interface.h
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  COMPONENT DEFINITION                                   RELEASE        */
+/*                                                                        */
+/*    tx_secure_interface.h                             Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This file defines the ThreadX secure thread stack components,       */
+/*    including data types and external references.                       */
+/*    It is assumed that tx_api.h and tx_port.h have already been         */
+/*    included.                                                           */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef TX_SECURE_INTERFACE_H
+#define TX_SECURE_INTERFACE_H
+
+/* Define SVC numbers used to call CMSIS TrustZone secure context functions.  */
+
+#define TX_SVC_NUM_SECURE_ALLOC               1
+#define TX_SVC_NUM_SECURE_FREE                2
+#define TX_SVC_NUM_SECURE_INIT                3
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_iar.c
+++ b/ports/cortex_m_cmsis/src/tx_iar.c
@@ -1,0 +1,799 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   IAR Multithreaded Library Support                                   */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+
+/* Define IAR library for tools prior to version 8.  */
+
+#if (__VER__ < 8000000)
+
+
+/* IAR version 7 and below.  */
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_initialize.h"
+#include "tx_thread.h"
+#include "tx_mutex.h"
+
+
+/* This implementation requires that the following macros are defined in the 
+   tx_port.h file and <yvals.h> is included with the following code segments:
+   
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#include <yvals.h>
+#endif
+
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#define TX_THREAD_EXTENSION_2           VOID    *tx_thread_iar_tls_pointer;          
+#else
+#define TX_THREAD_EXTENSION_2          
+#endif
+
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)                      thread_ptr -> tx_thread_iar_tls_pointer =  __iar_dlib_perthread_allocate();                                  
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                      __iar_dlib_perthread_deallocate(thread_ptr -> tx_thread_iar_tls_pointer); \
+                                                                    thread_ptr -> tx_thread_iar_tls_pointer =  TX_NULL;            
+#define TX_PORT_SPECIFIC_PRE_SCHEDULER_INITIALIZATION               __iar_dlib_perthread_access(0);
+#else
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)                                  
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                                  
+#endif
+
+    This should be done automatically if TX_ENABLE_IAR_LIBRARY_SUPPORT is defined while building the ThreadX library and the 
+    application.  
+
+    Finally, the project options General Options -> Library Configuration should have the "Enable thread support in library" box selected.
+*/
+
+#ifdef TX_ENABLE_IAR_LIBRARY_SUPPORT
+
+#include <yvals.h>
+
+TX_MUTEX    __tx_iar_system_lock_mutexes[_MAX_LOCK];
+UINT        __tx_iar_system_lock_next_free_mutex =  0;
+
+
+/* Define error counters, just for debug purposes.  */
+
+UINT        __tx_iar_system_lock_no_mutexes;
+UINT        __tx_iar_system_lock_internal_errors;
+UINT        __tx_iar_system_lock_isr_caller;
+
+
+/* Define the TLS access function for the IAR library.  */
+
+void _DLIB_TLS_MEMORY *__iar_dlib_perthread_access(void _DLIB_TLS_MEMORY *symbp)
+{
+
+char _DLIB_TLS_MEMORY   *p = 0;
+    
+    /* Is there a current thread?  */
+    if (_tx_thread_current_ptr)
+      p = (char _DLIB_TLS_MEMORY *) _tx_thread_current_ptr -> tx_thread_iar_tls_pointer;
+    else
+      p = (void _DLIB_TLS_MEMORY *) __segment_begin("__DLIB_PERTHREAD");
+    p += __IAR_DLIB_PERTHREAD_SYMBOL_OFFSET(symbp);
+    return (void _DLIB_TLS_MEMORY *) p;
+}
+
+
+/* Define mutexes for IAR library.  */
+
+void __iar_system_Mtxinit(__iar_Rmtx *m)
+{
+
+UINT        i;
+UINT        status;
+TX_MUTEX    *mutex_ptr;
+
+
+    /* First, find a free mutex in the list.  */
+    for (i = 0; i < _MAX_LOCK; i++)
+    {
+
+        /* Setup a pointer to the start of the next free mutex.  */
+        mutex_ptr =  &__tx_iar_system_lock_mutexes[__tx_iar_system_lock_next_free_mutex++];
+    
+        /* Check for wrap-around on the next free mutex.  */
+        if (__tx_iar_system_lock_next_free_mutex >= _MAX_LOCK)
+        {
+        
+            /* Yes, set the free index back to 0.  */
+            __tx_iar_system_lock_next_free_mutex =  0;
+        }
+    
+        /* Is this mutex free?  */
+        if (mutex_ptr -> tx_mutex_id != TX_MUTEX_ID)
+        {
+        
+            /* Yes, this mutex is free, get out of the loop!  */
+            break;
+        }
+    }
+
+    /* Determine if a free mutex was found.   */
+    if (i >= _MAX_LOCK)
+    {
+    
+        /* Error!  No more free mutexes!  */
+        
+        /* Increment the no mutexes error counter.  */
+        __tx_iar_system_lock_no_mutexes++;
+        
+        /* Set return pointer to NULL.  */
+        *m =  TX_NULL;
+        
+        /* Return.  */
+        return;
+    }
+    
+    /* Now create the ThreadX mutex for the IAR library.  */
+    status =  _tx_mutex_create(mutex_ptr, "IAR System Library Lock", TX_NO_INHERIT);
+    
+    /* Determine if the creation was successful.  */
+    if (status == TX_SUCCESS)
+    {
+    
+        /* Yes, successful creation, return mutex pointer.  */
+        *m =  (VOID *) mutex_ptr;
+    }
+    else
+    {
+    
+        /* Increment the internal error counter.  */
+        __tx_iar_system_lock_internal_errors++;
+    
+        /* Return a NULL pointer to indicate an error.  */
+        *m =  TX_NULL;
+    }
+}
+
+void __iar_system_Mtxdst(__iar_Rmtx *m)
+{
+
+    /* Simply delete the mutex.  */
+    _tx_mutex_delete((TX_MUTEX *) *m);
+}
+
+void __iar_system_Mtxlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex locks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Get the mutex.  */
+        status =  _tx_mutex_get((TX_MUTEX *) *m, TX_WAIT_FOREVER);
+
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_system_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_system_lock_isr_caller++;
+    }
+}
+
+void __iar_system_Mtxunlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex unlocks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Release the mutex.  */
+        status =  _tx_mutex_put((TX_MUTEX *) *m);
+        
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_system_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_system_lock_isr_caller++;
+    }
+}
+
+
+#if _DLIB_FILE_DESCRIPTOR
+
+TX_MUTEX    __tx_iar_file_lock_mutexes[_MAX_FLOCK];
+UINT        __tx_iar_file_lock_next_free_mutex =  0;
+
+
+/* Define error counters, just for debug purposes.  */
+
+UINT        __tx_iar_file_lock_no_mutexes;
+UINT        __tx_iar_file_lock_internal_errors;
+UINT        __tx_iar_file_lock_isr_caller;
+
+
+void __iar_file_Mtxinit(__iar_Rmtx *m)
+{
+
+UINT        i;
+UINT        status;
+TX_MUTEX    *mutex_ptr;
+
+
+    /* First, find a free mutex in the list.  */
+    for (i = 0; i < _MAX_FLOCK; i++)
+    {
+
+        /* Setup a pointer to the start of the next free mutex.  */
+        mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
+    
+        /* Check for wrap-around on the next free mutex.  */
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        {
+        
+            /* Yes, set the free index back to 0.  */
+            __tx_iar_file_lock_next_free_mutex =  0;
+        }
+    
+        /* Is this mutex free?  */
+        if (mutex_ptr -> tx_mutex_id != TX_MUTEX_ID)
+        {
+        
+            /* Yes, this mutex is free, get out of the loop!  */
+            break;
+        }
+    }
+
+    /* Determine if a free mutex was found.   */
+    if (i >= _MAX_LOCK)
+    {
+    
+        /* Error!  No more free mutexes!  */
+        
+        /* Increment the no mutexes error counter.  */
+        __tx_iar_file_lock_no_mutexes++;
+        
+        /* Set return pointer to NULL.  */
+        *m =  TX_NULL;
+        
+        /* Return.  */
+        return;
+    }
+    
+    /* Now create the ThreadX mutex for the IAR library.  */
+    status =  _tx_mutex_create(mutex_ptr, "IAR File Library Lock", TX_NO_INHERIT);
+    
+    /* Determine if the creation was successful.  */
+    if (status == TX_SUCCESS)
+    {
+    
+        /* Yes, successful creation, return mutex pointer.  */
+        *m =  (VOID *) mutex_ptr;
+    }
+    else
+    {
+    
+        /* Increment the internal error counter.  */
+        __tx_iar_file_lock_internal_errors++;
+    
+        /* Return a NULL pointer to indicate an error.  */
+        *m =  TX_NULL;
+    }
+}
+
+void __iar_file_Mtxdst(__iar_Rmtx *m)
+{
+
+    /* Simply delete the mutex.  */
+    _tx_mutex_delete((TX_MUTEX *) *m);
+}
+
+void __iar_file_Mtxlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex locks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Get the mutex.  */
+        status =  _tx_mutex_get((TX_MUTEX *) *m, TX_WAIT_FOREVER);
+
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_file_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_file_lock_isr_caller++;
+    }
+}
+
+void __iar_file_Mtxunlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex unlocks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Release the mutex.  */
+        status =  _tx_mutex_put((TX_MUTEX *) *m);
+        
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_file_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_file_lock_isr_caller++;
+    }
+}
+#endif  /* _DLIB_FILE_DESCRIPTOR */
+
+#endif  /* TX_ENABLE_IAR_LIBRARY_SUPPORT  */
+
+#else   /* IAR version 8 and above.  */
+
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_initialize.h"
+#include "tx_thread.h"
+#include "tx_mutex.h"
+
+/* This implementation requires that the following macros are defined in the 
+   tx_port.h file and <yvals.h> is included with the following code segments:
+   
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#include <yvals.h>
+#endif
+
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+#define TX_THREAD_EXTENSION_2           VOID    *tx_thread_iar_tls_pointer;          
+#else
+#define TX_THREAD_EXTENSION_2          
+#endif
+
+#ifdef  TX_ENABLE_IAR_LIBRARY_SUPPORT
+void    *_tx_iar_create_per_thread_tls_area(void);
+void    _tx_iar_destroy_per_thread_tls_area(void *tls_ptr);
+void    __iar_Initlocks(void);
+
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)                      thread_ptr -> tx_thread_iar_tls_pointer =  __iar_dlib_perthread_allocate();                                  
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                      do {__iar_dlib_perthread_deallocate(thread_ptr -> tx_thread_iar_tls_pointer); \
+                                                                        thread_ptr -> tx_thread_iar_tls_pointer =  TX_NULL; } while(0);
+#define TX_PORT_SPECIFIC_PRE_SCHEDULER_INITIALIZATION               do {__iar_Initlocks();} while(0);
+#else
+#define TX_THREAD_CREATE_EXTENSION(thread_ptr)                                  
+#define TX_THREAD_DELETE_EXTENSION(thread_ptr)                                  
+#endif
+
+    This should be done automatically if TX_ENABLE_IAR_LIBRARY_SUPPORT is defined while building the ThreadX library and the 
+    application.  
+
+    Finally, the project options General Options -> Library Configuration should have the "Enable thread support in library" box selected.
+*/
+
+#ifdef TX_ENABLE_IAR_LIBRARY_SUPPORT
+
+#include <DLib_Threads.h>
+
+
+void * __aeabi_read_tp();
+
+void* _tx_iar_create_per_thread_tls_area();
+void _tx_iar_destroy_per_thread_tls_area(void *tls_ptr);
+
+#pragma section="__iar_tls$$DATA"
+
+/* Define the TLS access function for the IAR library.  */
+void * __aeabi_read_tp(void)
+{
+  void *p = 0;
+  TX_THREAD *thread_ptr = _tx_thread_current_ptr;
+  if (thread_ptr)
+  {
+    p = thread_ptr->tx_thread_iar_tls_pointer;      
+  }
+  else
+  {
+    p = __section_begin("__iar_tls$$DATA");
+  }
+  return p;
+}
+
+/* Define the TLS creation and destruction to use malloc/free.  */
+
+void* _tx_iar_create_per_thread_tls_area()
+{
+  UINT tls_size = __iar_tls_size();  
+  
+  /* Get memory for TLS.  */  
+  void *p = malloc(tls_size);
+
+  /* Initialize TLS-area and run constructors for objects in TLS */
+  __iar_tls_init(p);
+  return p;
+}
+
+void _tx_iar_destroy_per_thread_tls_area(void *tls_ptr)
+{
+  /* Destroy objects living in TLS */
+  __call_thread_dtors();
+  free(tls_ptr);  
+}
+
+#ifndef _MAX_LOCK
+#define _MAX_LOCK 4
+#endif
+
+static TX_MUTEX    __tx_iar_system_lock_mutexes[_MAX_LOCK];
+static UINT        __tx_iar_system_lock_next_free_mutex =  0;
+
+
+/* Define error counters, just for debug purposes.  */
+
+UINT        __tx_iar_system_lock_no_mutexes;
+UINT        __tx_iar_system_lock_internal_errors;
+UINT        __tx_iar_system_lock_isr_caller;
+
+
+/* Define mutexes for IAR library.  */
+
+void __iar_system_Mtxinit(__iar_Rmtx *m)
+{
+
+UINT        i;
+UINT        status;
+TX_MUTEX    *mutex_ptr;
+
+
+    /* First, find a free mutex in the list.  */
+    for (i = 0; i < _MAX_LOCK; i++)
+    {
+
+        /* Setup a pointer to the start of the next free mutex.  */
+        mutex_ptr =  &__tx_iar_system_lock_mutexes[__tx_iar_system_lock_next_free_mutex++];
+    
+        /* Check for wrap-around on the next free mutex.  */
+        if (__tx_iar_system_lock_next_free_mutex >= _MAX_LOCK)
+        {
+        
+            /* Yes, set the free index back to 0.  */
+            __tx_iar_system_lock_next_free_mutex =  0;
+        }
+    
+        /* Is this mutex free?  */
+        if (mutex_ptr -> tx_mutex_id != TX_MUTEX_ID)
+        {
+        
+            /* Yes, this mutex is free, get out of the loop!  */
+            break;
+        }
+    }
+
+    /* Determine if a free mutex was found.   */
+    if (i >= _MAX_LOCK)
+    {
+    
+        /* Error!  No more free mutexes!  */
+        
+        /* Increment the no mutexes error counter.  */
+        __tx_iar_system_lock_no_mutexes++;
+        
+        /* Set return pointer to NULL.  */
+        *m =  TX_NULL;
+        
+        /* Return.  */
+        return;
+    }
+    
+    /* Now create the ThreadX mutex for the IAR library.  */
+    status =  _tx_mutex_create(mutex_ptr, "IAR System Library Lock", TX_NO_INHERIT);
+    
+    /* Determine if the creation was successful.  */
+    if (status == TX_SUCCESS)
+    {
+    
+        /* Yes, successful creation, return mutex pointer.  */
+        *m =  (VOID *) mutex_ptr;
+    }
+    else
+    {
+    
+        /* Increment the internal error counter.  */
+        __tx_iar_system_lock_internal_errors++;
+    
+        /* Return a NULL pointer to indicate an error.  */
+        *m =  TX_NULL;
+    }
+}
+
+void __iar_system_Mtxdst(__iar_Rmtx *m)
+{
+
+    /* Simply delete the mutex.  */
+    _tx_mutex_delete((TX_MUTEX *) *m);
+}
+
+void __iar_system_Mtxlock(__iar_Rmtx *m)
+{
+  if (*m)
+  {  
+    UINT    status;
+
+    /* Determine the caller's context. Mutex locks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Get the mutex.  */
+        status =  _tx_mutex_get((TX_MUTEX *) *m, TX_WAIT_FOREVER);
+
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_system_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_system_lock_isr_caller++;
+    }
+  }
+}
+
+void __iar_system_Mtxunlock(__iar_Rmtx *m)
+{
+  if (*m)
+  {
+    UINT    status;
+
+    /* Determine the caller's context. Mutex unlocks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Release the mutex.  */
+        status =  _tx_mutex_put((TX_MUTEX *) *m);
+        
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_system_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_system_lock_isr_caller++;
+    }
+  }
+}
+
+
+#if _DLIB_FILE_DESCRIPTOR
+
+#include <stdio.h>                        /* Added to get access to FOPEN_MAX */
+#ifndef _MAX_FLOCK
+#define _MAX_FLOCK FOPEN_MAX              /* Define _MAX_FLOCK as the maximum number of open files */
+#endif
+
+
+TX_MUTEX    __tx_iar_file_lock_mutexes[_MAX_FLOCK];
+UINT        __tx_iar_file_lock_next_free_mutex =  0;
+
+
+/* Define error counters, just for debug purposes.  */
+
+UINT        __tx_iar_file_lock_no_mutexes;
+UINT        __tx_iar_file_lock_internal_errors;
+UINT        __tx_iar_file_lock_isr_caller;
+
+
+void __iar_file_Mtxinit(__iar_Rmtx *m)
+{
+
+UINT        i;
+UINT        status;
+TX_MUTEX    *mutex_ptr;
+
+
+    /* First, find a free mutex in the list.  */
+    for (i = 0; i < _MAX_FLOCK; i++)
+    {
+
+        /* Setup a pointer to the start of the next free mutex.  */
+        mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
+    
+        /* Check for wrap-around on the next free mutex.  */
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        {
+        
+            /* Yes, set the free index back to 0.  */
+            __tx_iar_file_lock_next_free_mutex =  0;
+        }
+    
+        /* Is this mutex free?  */
+        if (mutex_ptr -> tx_mutex_id != TX_MUTEX_ID)
+        {
+        
+            /* Yes, this mutex is free, get out of the loop!  */
+            break;
+        }
+    }
+
+    /* Determine if a free mutex was found.   */
+    if (i >= _MAX_LOCK)
+    {
+    
+        /* Error!  No more free mutexes!  */
+        
+        /* Increment the no mutexes error counter.  */
+        __tx_iar_file_lock_no_mutexes++;
+        
+        /* Set return pointer to NULL.  */
+        *m =  TX_NULL;
+        
+        /* Return.  */
+        return;
+    }
+    
+    /* Now create the ThreadX mutex for the IAR library.  */
+    status =  _tx_mutex_create(mutex_ptr, "IAR File Library Lock", TX_NO_INHERIT);
+    
+    /* Determine if the creation was successful.  */
+    if (status == TX_SUCCESS)
+    {
+    
+        /* Yes, successful creation, return mutex pointer.  */
+        *m =  (VOID *) mutex_ptr;
+    }
+    else
+    {
+    
+        /* Increment the internal error counter.  */
+        __tx_iar_file_lock_internal_errors++;
+    
+        /* Return a NULL pointer to indicate an error.  */
+        *m =  TX_NULL;
+    }
+}
+
+void __iar_file_Mtxdst(__iar_Rmtx *m)
+{
+
+    /* Simply delete the mutex.  */
+    _tx_mutex_delete((TX_MUTEX *) *m);
+}
+
+void __iar_file_Mtxlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex locks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Get the mutex.  */
+        status =  _tx_mutex_get((TX_MUTEX *) *m, TX_WAIT_FOREVER);
+
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_file_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_file_lock_isr_caller++;
+    }
+}
+
+void __iar_file_Mtxunlock(__iar_Rmtx *m)
+{
+
+UINT    status;
+
+
+    /* Determine the caller's context. Mutex unlocks are only available from initialization and 
+       threads.  */
+    if ((_tx_thread_system_state == 0) || (_tx_thread_system_state >= TX_INITIALIZE_IN_PROGRESS))
+    {
+    
+        /* Release the mutex.  */
+        status =  _tx_mutex_put((TX_MUTEX *) *m);
+        
+        /* Check the status of the mutex release.  */
+        if (status)
+        {
+        
+            /* Internal error, increment the counter.  */
+            __tx_iar_file_lock_internal_errors++;
+        }
+    }
+    else
+    {
+        
+        /* Increment the ISR caller error.  */
+        __tx_iar_file_lock_isr_caller++;
+    }
+}
+#endif  /* _DLIB_FILE_DESCRIPTOR */
+
+#endif  /* TX_ENABLE_IAR_LIBRARY_SUPPORT  */
+
+#endif /* IAR version 8 and above.  */

--- a/ports/cortex_m_cmsis/src/tx_isr_end.c
+++ b/ports/cortex_m_cmsis/src/tx_isr_end.c
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   ISR                                                                 */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#ifdef TX_ENABLE_EVENT_TRACE
+#include "tx_trace.h"
+#endif
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+#include "tx_execution_profile.h"
+#endif
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    tx_isr_end                                          Cortex-M        */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for indicating the end of processing   */
+/*    for the specified interrupt. This is purely for diagnostic use with */
+/*    either TraceX or execution profiling.                               */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_trace_isr_exit_insert         Mark the end of an ISR            */
+/*    _tx_execution_isr_exit            Mark the end of ISR processing    */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    ISR                                                                 */
+/*                                                                        */
+/**************************************************************************/
+
+#if defined(TX_ENABLE_EVENT_TRACE) || defined(TX_ENABLE_EXECUTION_CHANGE_NOTIFY)
+ 
+VOID  tx_isr_end(ULONG isr_id)
+{
+
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+TX_INTERRUPT_SAVE_AREA
+#endif
+
+#ifdef TX_ENABLE_EVENT_TRACE
+
+    /* Indicate the end of the ISR in the trace buffer.  */
+    _tx_trace_isr_exit_insert(isr_id);
+#else
+    (void) isr_id;
+#endif    
+    
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+
+    /* Disable interrupts.  */
+    TX_DISABLE
+    
+    /* Indicate the end of ISR processing.  */
+    _tx_execution_isr_exit();
+
+    /* Restore interrupts.  */
+    TX_RESTORE
+#endif
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_isr_start.c
+++ b/ports/cortex_m_cmsis/src/tx_isr_start.c
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   ISR                                                                 */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#ifdef TX_ENABLE_EVENT_TRACE
+#include "tx_trace.h"
+#endif
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+#include "tx_execution_profile.h"
+#endif
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    tx_isr_start                                      Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for indicating the start of processing */
+/*    for the specified interrupt. This is purely for diagnostic use with */
+/*    either TraceX or execution profiling.                               */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_trace_isr_enter_insert        Mark the beginning of an ISR      */
+/*    _tx_execution_isr_enter           Mark the start of ISR processing  */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    ISR                                                                 */
+/*                                                                        */
+/**************************************************************************/
+
+#if defined(TX_ENABLE_EVENT_TRACE) || defined(TX_ENABLE_EXECUTION_CHANGE_NOTIFY)
+
+VOID  tx_isr_start(ULONG isr_id)
+{
+
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+TX_INTERRUPT_SAVE_AREA
+#endif
+
+#ifdef TX_ENABLE_EVENT_TRACE
+
+    /* Indicate the start of the ISR in the trace buffer.  */
+    _tx_trace_isr_enter_insert(isr_id);
+#else
+    (void) isr_id;
+#endif     
+    
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+
+    /* Disable interrupts.  */
+    TX_DISABLE
+    
+    /* Indicate the start of ISR processing (and suspension of interrupted processing).  */
+    _tx_execution_isr_enter();
+
+    /* Restore interrupts.  */
+    TX_RESTORE
+#endif
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_thread_interrupt_control.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_interrupt_control.c
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+/* #define TX_SOURCE_CODE  */
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_thread.h"
+#include "tx_cmsis.h"
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_interrupt_control                      Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for changing the interrupt lockout     */
+/*    posture of the system.                                              */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    new_posture                           New interrupt lockout posture */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    old_posture                           Old interrupt lockout posture */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT _tx_thread_interrupt_control (UINT new_posture)
+{
+    UINT old_posture;
+
+#ifdef TX_PORT_USE_BASEPRI
+
+    /* Pickup current interrupt lockout posture.  */
+    old_posture = __get_BASEPRI();
+
+    /* Apply the new interrupt posture.  */
+    UINT new_basepri = 0U;
+    if (new_posture > 0)
+    {
+        new_basepri = TX_PORT_MAX_IPL << (8U - __NVIC_PRIO_BITS);
+    }
+    __set_BASEPRI(new_basepri);
+
+#else
+
+    /* Pickup current interrupt lockout posture.  */
+    old_posture = __get_PRIMASK();
+
+    /* Apply the new interrupt posture.  */
+    __set_PRIMASK(new_posture);
+
+#endif
+
+    /* Return the original value */
+    return old_posture;
+}

--- a/ports/cortex_m_cmsis/src/tx_thread_interrupt_disable.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_interrupt_disable.c
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_thread.h"
+
+UINT _tx_thread_interrupt_disable(VOID);
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_interrupt_restore                      Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for disabling interrupts and returning */
+/*    the previous interrupt lockout posture.                             */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    old_posture                           Old interrupt lockout posture */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT _tx_thread_interrupt_disable (VOID)
+{
+    UINT old_posture;
+
+#ifdef TX_PORT_USE_BASEPRI
+
+    /* Pickup current interrupt lockout posture.  */
+    old_posture = __get_BASEPRI();
+
+    /* Disable interrupts */
+    __set_BASEPRI(TX_PORT_MAX_IPL << (8U - __NVIC_PRIO_BITS));
+
+#else
+
+    /* Pickup current interrupt lockout posture.  */
+    old_posture = __get_PRIMASK();
+
+    /* Disable interrupts */
+    __disable_irq();
+
+#endif
+
+    /* Return old interrupt lockout posture.  */
+    return old_posture;
+}

--- a/ports/cortex_m_cmsis/src/tx_thread_interrupt_restore.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_interrupt_restore.c
@@ -1,0 +1,73 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_thread.h"
+
+VOID _tx_thread_interrupt_restore(UINT new_posture);
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_interrupt_restore                      Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is responsible for restoring the previous             */
+/*    interrupt lockout posture.                                          */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    previous_posture                      Previous interrupt posture    */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+VOID _tx_thread_interrupt_restore (UINT new_posture)
+{
+#ifdef TX_PORT_USE_BASEPRI
+
+    /* Restore previous interrupt lockout posture.  */
+    __set_BASEPRI(new_posture);
+
+#else
+
+    /* Restore previous interrupt lockout posture.  */
+    __set_PRIMASK(new_posture);
+
+#endif
+}

--- a/ports/cortex_m_cmsis/src/tx_thread_schedule.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_schedule.c
@@ -1,0 +1,796 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_timer.h"
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+ #include "tx_secure_interface.h"
+#endif
+
+#ifdef __ARM_ARCH_7EM__                // CM4
+ #define TX_PORT_ISA_CBZ_SUPPORTED
+ #define TX_PORT_ISA_STMDB_LDMIA_SUPPORTED
+ #define TX_PORT_ISA_THUMB2_SUB_ADD_SUPPORTED
+ #define TX_PORT_ISA_IT_SUPPORTED
+#endif
+
+#ifdef __ARM_ARCH_8M_MAIN__            // CM33
+ #define TX_PORT_ISA_CBZ_SUPPORTED
+ #define TX_PORT_ISA_STMDB_LDMIA_SUPPORTED
+ #define TX_PORT_ISA_THUMB2_SUB_ADD_SUPPORTED
+ #define TX_PORT_ISA_IT_SUPPORTED
+#endif
+
+#ifdef __ARM_ARCH_8M_BASE__            // CM23
+ #define TX_PORT_ISA_CBZ_SUPPORTED
+#endif
+
+/* This must follow the definition for each core instruction set. IAR does not support CBZ in inline assembly. */
+#ifdef __IAR_SYSTEMS_ICC__
+ #undef TX_PORT_ISA_CBZ_SUPPORTED
+#endif
+
+/* Used to generate a compiler error (negative array size error) if the assertion fails.  This is used in place of "#error"
+ * for expressions that cannot be evaluated by the preprocessor like offsetof(). */
+#ifndef TX_PORT_COMPILE_TIME_ASSERT
+ #define TX_PORT_COMPILE_TIME_ASSERT(e)    ((void) sizeof(char[1 - 2 * !(e)]))
+#endif
+
+/* Used to convert an evaluated macro into a string. */
+#define TX_PORT_STRINGIFY_EXPANDED(s)      TX_PORT_STRINGIFY(s)
+
+/* Used to convert text into a string. */
+#define TX_PORT_STRINGIFY(s)               #s
+
+/* The scheduler stacks r4-r11 (and LR if the MCU has an FPU) in PendSV_Handler, but PSPLIM will not detect a stack
+ * overflow because PSP is not used in handler mode. TX_PORT_SCHEDULER_STACK is used to move PSPLIM to account for
+ * this. TX_PORT_SCHEDULER_STACK must be a multiple of 8. */
+#if __FPU_USED
+#define TX_PORT_SCHEDULER_STACK    40
+#else
+#define TX_PORT_SCHEDULER_STACK    32
+#endif
+
+/* The following macros are defined as hard coded numbers so they can be converted to strings in the
+ * assembly language of PendSV_Handler. They are verified to be correct using compile time assertions
+ * at the beginning of PendSV_Handler. */
+
+/* The following offsets are relative to the base of the TX_THREAD structure.  For example:
+ * offsetof(TX_THREAD, tx_thread_run_count) == 4 */
+#define TX_PORT_OFFSET_RUN_COUNT      4
+#define TX_PORT_OFFSET_STACK_PTR      8
+#define TX_PORT_OFFSET_STACK_START    12
+#define TX_PORT_OFFSET_STACK_END      16
+#define TX_PORT_OFFSET_TIME_SLICE     24
+
+#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__)
+ #define TX_PORT_NAKED_FUNCTION       __attribute__((naked, no_instrument_function, \
+                                                     no_profile_instrument_function))
+#else
+ #define TX_PORT_NAKED_FUNCTION       __attribute__((naked))
+#endif
+
+TX_PORT_NAKED_FUNCTION VOID PendSV_Handler(VOID);
+TX_PORT_NAKED_FUNCTION VOID SVC_Handler(VOID);
+VOID                        SysTick_Handler(VOID);
+
+VOID _tx_thread_schedule(VOID);
+
+VOID _tx_port_svc_handler(UINT * caller_stack_ptr);
+
+extern TX_THREAD * volatile _tx_thread_current_ptr;
+extern TX_THREAD * volatile _tx_thread_execute_ptr;
+extern volatile UINT        _tx_thread_preempt_disable;
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/* offsetof() cannot be used directly in inline assembly.  offsetof() is required for the offset to
+ * tx_thread_secure_stack_context because this offset may change if the thread extensions in the TX_THREAD
+ * structure (for example, TX_THREAD_EXTENSION_0) are used. */
+
+/* This cannot be static because the compiler is not aware it is reference in the assembly code. */
+const uint32_t g_secure_stack_offset = offsetof(TX_THREAD, tx_thread_secure_stack_context);
+#endif
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_schedule                               Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function waits for a thread control block pointer to appear in */
+/*    the _tx_thread_execute_ptr variable.  Once a thread pointer appears */
+/*    in the variable, the corresponding thread is resumed.               */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    _tx_initialize_kernel_enter          ThreadX entry function         */
+/*    _tx_thread_system_return             Return to system from thread   */
+/*                                                                        */
+/**************************************************************************/
+VOID _tx_thread_schedule (VOID)
+{
+    /* The following compile time assertions validate offsets used in the assembly code
+     * of PendSV_Handler.  These assertions cannot be in PendSV_Handler because only
+     * assembly code is allowed in naked/stackless functions.  These statements generate
+     * build errors if the offset of any of the structure members used in this code changes.
+     * These structure offsets are hardcoded because offsetof() is not supported in inline
+     * assembly. */
+    TX_PORT_COMPILE_TIME_ASSERT(TX_PORT_OFFSET_RUN_COUNT == offsetof(TX_THREAD, tx_thread_run_count));
+    TX_PORT_COMPILE_TIME_ASSERT(TX_PORT_OFFSET_STACK_PTR == offsetof(TX_THREAD, tx_thread_stack_ptr));
+    TX_PORT_COMPILE_TIME_ASSERT(TX_PORT_OFFSET_STACK_START == offsetof(TX_THREAD, tx_thread_stack_start));
+    TX_PORT_COMPILE_TIME_ASSERT(TX_PORT_OFFSET_TIME_SLICE == offsetof(TX_THREAD, tx_thread_time_slice));
+
+    /* This function should only ever be called on Cortex-M from the first
+     * schedule request. Subsequent scheduling occurs from the PendSV handling
+     * routine below. */
+
+    /* Clear the preempt-disable flag to enable rescheduling after initialization on Cortex-M targets.  */
+    _tx_thread_preempt_disable = 0;
+
+#if __FPU_USED
+
+    /* Reset lazy stacking if the MCU has an FPU. */
+    __asm volatile (
+        "MRS     r12, CONTROL     \n"
+        "BIC     r12, r12, #4     \n"  // Clear FPCA.
+        "MSR     CONTROL, r12     \n"
+        :                              // No outputs
+        :                              // No inputs
+        : "r12"                        // Clobbers r12
+        );
+#endif
+
+    /* Enable interrupts */
+#ifdef TX_PORT_USE_BASEPRI
+    __set_BASEPRI(0U);
+#else
+    __enable_irq();
+#endif
+
+    /* Enter the scheduler for the first time.  */
+    SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
+
+    /* We should never get here - ever!  */
+    while (1)
+    {
+#ifdef TX_ENABLE_BKPT
+        __BKPT(0xEF);
+#endif
+#if defined(__ICCARM__)
+ #ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+        /* These functions are only called from inline assembly. They are
+         * referenced here to avoid an IAR linker error in non-secure
+         * TrustZone projects. */
+        TZ_StoreContext_S(0);
+        TZ_LoadContext_S(0);
+ #endif
+#endif
+    }
+}
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_port_wait_thread_ready                        Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    Waits for a new thread to become ready.                             */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Pointer to thread ready to run                                      */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    PendSV_Handler                                                      */
+/*                                                                        */
+/**************************************************************************/
+
+/* These variables are global because this function is called from PendSV_Handler, which is a stackless
+ * function. */
+__attribute((weak)) void * _tx_port_wait_thread_ready (VOID)
+{
+    /* The following is the idle wait processing. In this case, no threads are ready for execution and the
+     * system will simply be idle until an interrupt occurs that makes a thread ready. Note that interrupts
+     * are disabled to allow use of WFI for waiting for a thread to arrive.  */
+
+    TX_THREAD * new_thread_ptr;
+
+    while (1)
+    {
+        /* Disable interrupts - The next block is critical. Interrupts are disabled with PRIMASK event if
+         * BASEPRI is used elsewhere because the WFI wake condition includes interrupts masked by PRIMASK,
+         * but does not include interrupts masked by BASEPRI.
+         * https://developer.arm.com/documentation/100235/0002/the-cortex-m33-instruction-set/miscellaneous-instructions/wfi?lang=en
+         */
+        __disable_irq();
+
+        /* Make the new thread the current thread. */
+        new_thread_ptr         = _tx_thread_execute_ptr;
+        _tx_thread_current_ptr = new_thread_ptr;
+
+        /* If non-NULL, a new thread is ready! */
+        if (new_thread_ptr != 0)
+        {
+            /* At this point, we have a new thread ready to go.  */
+
+            /* Clear any newly pended PendSV - since we are already in the handler!  */
+            SCB->ICSR = SCB_ICSR_PENDSVCLR_Msk;
+
+            /* Re-enable interrupts. */
+            __enable_irq();
+            break;
+        }
+
+        /**
+         * DSB should be last instruction executed before WFI
+         * infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHICBGB.html
+         */
+        __DSB();
+
+        /* If there is a pending interrupt (wake up condition for WFI is true), the MCU does not enter low power mode:
+         * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/BABHHGEB.html
+         * After exiting from low power mode, interrupt must be re-enabled. */
+        __WFI();
+
+        /* Instruction Synchronization Barrier. */
+        __ISB();
+
+        /* Re-enable interrupts. */
+        __enable_irq();
+        __ISB();
+    }
+
+    return new_thread_ptr;
+}
+
+/* Generic context switching PendSV handler.  */
+TX_PORT_NAKED_FUNCTION VOID PendSV_Handler (VOID)
+{
+    /* This function is assembly only to meet the requirements for naked/stackless functions. For GCC, only basic
+     * assembly is allowed. The main stack is used when C functions are called. */
+
+    /* Before entry into this exception handler, the hardware stacks XPSR, PC, LR, r12, r3, r2, r1, and r0 onto the
+     * stack (typically the process stack of the executing thread). When the FPU is in use, the FPSCR and S0-S15
+     * registers are also stored on the stack. All other registers are stored by software in this function. */
+
+    /* Only r0-r3 and r12 can be used before stack preservation is complete. */
+
+    /* r0-r3 are not guaranteed to retain their values after C functions are called. */
+
+    /* An exception is granted in this case to allow commented out code.  Commented out equivalent C code is
+     * included before each section of assembly code that has a C equivalent.  This is done to improve readability
+     * and maintainability.  Commented out equivalent C code is in single line comments with no code on the
+     * same line. */
+    __asm volatile (
+#if defined(__GNUC__)
+        ".syntax unified                     \n"
+#endif
+
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+
+        /* Call the thread exit function to indicate the thread is no longer executing.  */
+
+        // _tx_execution_thread_exit();
+        "CPSID   i                           \n" // Disable interrupts
+        "PUSH    {r0, LR}                    \n" // Save LR since it has not been stored yet, and r0 to maintain double word stack aligment
+        "BL      _tx_execution_thread_exit   \n" // Call the thread exit function
+
+        /* r0-r3 are undefined after branches. */
+        "POP     {r0, LR}                    \n" // Restore r0 and LR
+        "CPSIE   i                           \n" // Enable interrupts
+#endif
+
+        /* Determine if there is a current thread to finish preserving.  */
+
+        // if (_tx_thread_current_ptr != 0)
+        // {
+        "LDR     r0, =_tx_thread_current_ptr \n" // Build current thread pointer address
+        "LDR     r1, [r0]                    \n" // Pickup current thread pointer
+        "CMP     r1, #0                      \n"
+
+        /* This branch is only taken the first time this function is called.  After that, there is always
+         * a current thread to save. */
+        "BEQ     __tx_no_current             \n"
+
+        /* Recover PSP and preserve current thread context.  */
+        "MRS     r3,  PSP                    \n" // Pickup PSP pointer (thread's stack pointer)
+
+#if defined(TX_PORT_VENDOR_STACK_MONITOR_ENABLE)
+ #ifdef TX_PORT_ISA_THUMB2_SUB_ADD_SUPPORTED
+        "SUB     r3,  r3, #32                \n" // Update PSP to utilize the HW stack monitor with the amount of room required to save r4-r11
+        "MSR     PSP, r3                     \n" // Update PSP to utilize the HW stack monitor
+        "ADD     r3,  r3, #32                \n" // Restore original PSP to r3 so we can continue stacking
+ #else
+        "SUBS    r3,  r3, #32                \n" // Update PSP to utilize the HW stack monitor with the amount of room required to save r4-r11
+        "MSR     PSP, r3                     \n" // Update PSP to utilize the HW stack monitor
+        "ADDS    r3,  r3, #32                \n" // Restore original PSP to r3 so we can continue stacking
+ #endif
+#endif
+#ifdef TX_PORT_ISA_STMDB_LDMIA_SUPPORTED
+        "STMDB   r3!, {r4-r11}               \n" // Save its remaining registers
+#else
+        "SUBS    r3,  r3, #16                \n" // Allocate stack space
+        "STM     r3!, {r4-r7}                \n" // Save its remaining registers (M33 Instruction: STMDB r3!, {r4-r11})
+        "MOV     r4,  r8                     \n"
+        "MOV     r5,  r9                     \n"
+        "MOV     r6,  r10                    \n"
+        "MOV     r7,  r11                    \n"
+        "SUBS    r3,  r3, #32                \n" // Allocate stack space
+        "STM     r3!, {r4-r7}                \n"
+        "SUBS    r3,  r3, #16                \n" // Allocate stack space
+#endif
+#if __FPU_USED
+        "TST     LR,  #0x10                  \n" // Determine if the VFP extended frame is present
+        "BNE     _skip_vfp_save              \n" // No, skip additional VFP save
+ #if defined(TX_PORT_VENDOR_STACK_MONITOR_ENABLE)
+        "SUB     r3,  r3, #64                \n" // Calculate the amount of room required to save s16-s31
+        "MSR     PSP, r3                     \n" // Update PSP to utilize the HW stack monitor
+        "ADD     r3,  r3, #64                \n" // Restore original PSP to r3 so we can continue stacking
+ #endif
+        "VSTMDB  r3!, {s16-s31}              \n" // Yes, save additional VFP registers
+        "_skip_vfp_save:                     \n"
+        "STMDB   r3!, {LR}                   \n" // Save LR on the stack
+#endif
+
+        // [r1, #TX_PORT_OFFSET_STACK_PTR] == _tx_thread_current_ptr->tx_thread_stack_ptr
+        "STR     r3, [r1, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_STACK_PTR) /* Save its stack pointer */
+        "]                                   \n"
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+        /* Load the offset of tx_thread_secure_stack_context in r12. */
+        "LDR     r12, =g_secure_stack_offset \n" // r12 = &g_secure_stack_offset
+        "LDR     r12, [r12]                  \n" // r12 = g_secure_stack_offset
+
+        // Save secure context
+        "PUSH    {r0, r1}                    \n" // Save r1 (_tx_thread_current_ptr) and r0 to maintain double word stack alignment
+        "LDR     r0, [r1, r12]               \n" // Load secure stack index
+ #ifdef TX_PORT_ISA_CBZ_SUPPORTED
+        "CBZ     r0, _skip_secure_save       \n" // Skip save if there is no secure context
+ #else
+        "CMP     r0, #0                      \n"
+        "BEQ     _skip_secure_save           \n"
+ #endif
+        "BL      TZ_StoreContext_S           \n" // r0 must = secure stack index.
+        "_skip_secure_save:                  \n"
+        "POP     {r0, r1}                    \n" // Restore r0 and r1
+#endif
+
+        /* Stack preservation is complete. */
+
+        /* Determine if time-slice is active. If it isn't, skip time handling processing.  */
+
+        // if (_tx_timer_time_slice != 0)
+        // {
+        "LDR     r4, =_tx_timer_time_slice   \n" // Build address of time-slice variable
+
+        "LDR     r3, [r4]                    \n" // Pickup current time-slice
+#ifdef TX_PORT_ISA_CBZ_SUPPORTED
+        "CBZ     r3, __tx_ts_new             \n" // If not active, skip processing
+#else
+        "CMP     r3, #0                      \n"
+        "BEQ     __tx_ts_new                 \n"
+#endif
+
+        /* Time-slice is active, save the current thread's time-slice and clear the global time-slice variable.  */
+
+        // _tx_thread_current_ptr->tx_thread_time_slice = _tx_timer_time_slice;
+        "STR     r3, [r1, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_TIME_SLICE) /* Save current time-slice */
+        "]                                   \n"
+
+        /* Clear the global time-slice.  */
+
+        // _tx_timer_time_slice = 0;
+        "MOVS    r3, #0                      \n" // Build clear value
+        "STR     r3, [r4]                    \n" // Clear time-slice
+
+        // }
+
+        /* The executing thread is now completely preserved!!!  */
+
+        // }
+
+        /* Now we are looking for a new thread to execute!  */
+        "__tx_ts_new:                        \n"
+
+        /* Get the address of the new thread. */
+        "LDR     r6, =_tx_thread_execute_ptr \n" // Build execute thread pointer address
+
+        /* Is there a thread ready to execute?  */
+
+        // if (_tx_thread_execute_ptr == 0)
+        // {
+        // _tx_port_wait_thread_ready();
+        "LDR     r6, [r6]                    \n" // Is there another thread ready to execute?
+#ifdef TX_PORT_ISA_CBZ_SUPPORTED
+        "CBZ     r6, __tx_ts_wait            \n" // No, skip to the wait processing
+#else
+        "CMP     r6, #0                      \n"
+        "BEQ     __tx_ts_wait                \n"
+#endif
+
+        // }
+        // else
+        // {
+
+        /* Yes, another thread is ready for execution, make the current thread the new thread.  */
+
+        // _tx_thread_current_ptr = _tx_thread_execute_ptr;
+
+        "STR r6, [r0]                        \n" // Setup the current thread pointer to the new thread
+
+        // }
+
+        /* At this point, r6 must contain a pointer to the new thread. */
+
+        "__tx_ts_restore:                    \n"
+
+        /* Restore the thread.  */
+
+        /* Increment the thread run count.  */
+
+        // _tx_thread_current_ptr->tx_thread_run_count++;
+        "LDR  r0, [r6, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_RUN_COUNT)
+        "]                                   \n" // Pickup the current thread run count
+        "ADDS r0, r0, #1                     \n" // Increment the thread run count
+        "STR  r0, [r6, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_RUN_COUNT)
+        "]                                   \n" // Store the new run count
+
+        /* Setup global time-slice with thread's current time-slice.  */
+
+        // _tx_timer_time_slice = _tx_thread_current_ptr->tx_thread_time_slice;
+        "LDR r0, [r6, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_TIME_SLICE)
+        "]                                   \n" // Pickup thread's current time-slice
+        "STR r0, [r4]                        \n" // Setup global time-slice
+
+#ifdef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
+
+        /* Call the thread entry function to indicate the thread is executing.  */
+
+        // _tx_execution_thread_enter();
+        "CPSID   i                           \n" // Disable interrupts
+        "BL  _tx_execution_thread_enter      \n" // Call the thread enter function
+        "CPSIE   i                           \n" // Enable interrupts
+
+        /* r0-r3 are undefined after branches. */
+#endif
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+        /* Load the offset of tx_thread_secure_stack_context in r12. */
+        "LDR     r12, =g_secure_stack_offset \n" // r12 = &g_secure_stack_offset
+        "LDR     r12, [r12]                  \n" // r12 = g_secure_stack_offset
+
+        // Restore secure context
+        // r0 = _tx_thread_current_ptr->tx_thread_secure_stack_context
+        "LDR     r0, [r6, r12]               \n" // Load secure stack index
+ #ifdef TX_PORT_ISA_CBZ_SUPPORTED
+        "CBZ     r0, _skip_secure_restore    \n" // Skip restore if there is no secure context
+ #else
+        "CMP     r0, #0                      \n"
+        "BEQ     _skip_secure_restore        \n"
+ #endif
+        "BL      TZ_LoadContext_S            \n" // Restore secure stack, secure context must be in r0
+        "_skip_secure_restore:               \n"
+#endif
+
+#ifdef TX_PORT_VENDOR_STACK_MONITOR_ENABLE
+
+        /* Allow vendors to disable custom stack monitor hardware and reconfigure for the new thread.
+         * Vendors can find the new thread pointer in r6. */
+        TX_PORT_VENDOR_ASM_STACK_MONITOR_CONFIGURE
+#endif
+
+#ifdef TX_PORT_PSPLIM_PRESENT
+
+        /* Set PSPLIM to the beginning of the thread stack. */
+        "LDR     r1, [r6, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_STACK_START)
+        "]                                   \n"
+        "ADD     r1,  r1, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_SCHEDULER_STACK)
+        "                                    \n" // Update PSP to utilize the HW stack monitor with the amount of room required to save r4-r11
+        "MSR     PSPLIM, r1                  \n"
+#endif
+
+        /* Restore the thread context and PSP.  */
+
+        /* Get stack pointer for this thread. */
+
+        // [r6, #TX_PORT_OFFSET_STACK_PTR] == _tx_thread_current_ptr->tx_thread_stack_ptr
+        "LDR     r3, [r6, #"TX_PORT_STRINGIFY_EXPANDED (TX_PORT_OFFSET_STACK_PTR)
+        "]                                   \n"
+
+#if __FPU_USED
+
+        /* Set LR (EXC_RETURN) to the value saved on the stack. LR is used to determine if FPU registers need
+         * to be restored. */
+        "LDMIA   r3!, {LR}                   \n"
+#else
+
+        /* Return to thread on process stack */
+        "LDR r1, =0xFFFFFFFD                 \n"
+
+        /* Set LR (EXC_RETURN) to 0xFFFFFFFD. Return to Thread mode, exception return uses non-floating-point state
+         * from the PSP and execution uses PSP after return. */
+        "MOV LR, r1                          \n"
+#endif
+
+#if __FPU_USED
+        "TST     LR, #0x10                   \n" // Determine if the VFP extended frame is present
+        "BNE     _skip_vfp_restore           \n" // If so, restore additional VFP registers and setup the proper exception return
+        "VLDMIA  r3!, {s16-s31}              \n" // Yes, restore additional VFP registers
+        "_skip_vfp_restore:                  \n"
+#endif
+#ifdef TX_PORT_ISA_STMDB_LDMIA_SUPPORTED
+        "LDMIA   r3!, {r4-r11}               \n" // Recover thread's registers
+#else
+        "LDM     r3!, {r4-r7}                \n" // Recover thread's registers (M4 Instruction: LDMIA r3!, {r4-r11} )
+        "MOV     r11, r7                     \n"
+        "MOV     r10, r6                     \n"
+        "MOV     r9,  r5                     \n"
+        "MOV     r8,  r4                     \n"
+        "LDM     r3!, {r4-r7}                \n"
+#endif
+        "MSR     PSP, r3                     \n"
+
+#ifdef TX_PORT_VENDOR_STACK_MONITOR_ENABLE
+
+        /* Allow vendors to enable custom stack monitor hardware. */
+        TX_PORT_VENDOR_ASM_STACK_MONITOR_ENABLE
+#endif
+
+        /* Return to the thread.  */
+        "BX      LR                          \n"
+
+        /* We should never get here!  */
+#ifdef TX_ENABLE_BKPT
+        "BKPT    0                           \n"
+#endif
+
+        // while(1);
+        "__tx_error:                         \n"
+        "B       __tx_error                  \n"
+
+        "__tx_no_current:                    \n"
+
+        /* There is no current thread.  Load r4 with the value determined during thread preservation. */
+        "LDR     r4, =_tx_timer_time_slice   \n" // Build address of time-slice variable
+
+        "B __tx_ts_new                       \n"
+
+        /* If no thread is ready to execute, wait until one becomes ready.  */
+        "__tx_ts_wait:                       \n"
+        "BL      _tx_port_wait_thread_ready  \n"
+
+        /* r0 contains the base address of the thread ready to execute. Move it to r6 so the value
+         * is persistent through function calls. */
+        "MOV     r6, r0                      \n"
+
+        "B       __tx_ts_restore             \n" // Restore the thread
+
+        );
+}
+
+/* Moved from tx_timer_interrupt.c to ensure this code is not removed by the linker. */
+#ifndef TX_NO_TIMER
+extern VOID _tx_timer_interrupt(VOID);
+
+/* System tick timer. */
+VOID SysTick_Handler (VOID)
+{
+    _tx_timer_interrupt();
+}
+
+#endif
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/* SVC_Handler is not needed when ThreadX is running in single mode. In TrustZone projects, this
+ * is used to allocate or free secure stack space. */
+void SVC_Handler (void)
+{
+    /* This is a naked/stackless function. Do not pass arguments to the inline assembly when the GCC compiler is
+     * used. */
+    __asm volatile (
+ #if defined(__GNUC__)
+        ".syntax unified                         \n"
+ #endif
+
+        /* Save stack pointer in r0, then call _tx_port_svc_handler.
+         *
+         * Bit 2 of EXC_RETURN is SPSEL: Indicates which stack contains the exception stack frame.
+         *   0 = MSP
+         *   1 = PSP
+         */
+
+ #ifdef TX_PORT_ISA_IT_SUPPORTED
+        "TST     LR, #4                          \n" // Determine return stack from EXC_RETURN bit 2
+        "ITE     EQ                              \n"
+        "MRSEQ   r0, MSP                         \n" // Get MSP if return stack is MSP
+        "MRSNE   r0, PSP                         \n" // Get PSP if return stack is PSP
+        "LDR     r1, =_tx_port_svc_handler       \n"
+        "BX      r1                              \n" // Branch to _tx_port_svc_handler, with exception stack pointer in r0.
+ #else
+        "LDR     r2, =_tx_port_svc_handler       \n"
+        "MOVS    r0, #4                          \n"
+        "MOV     r1, LR                          \n"
+        "TST     r0, r1                          \n" // Determine return stack from EXC_RETURN bit 2
+        "BEQ _stacking_used_msp                  \n" // Get MSP if return stack is MSP
+        "MRS     r0, PSP                         \n" // Get PSP if return stack is PSP
+        "BX r2                                   \n" // Branch to _tx_port_svc_handler, with exception stack pointer in r0.
+        "_stacking_used_msp:                     \n"
+        "MRS     r0, MSP                         \n"
+        "BX r2                                   \n" // Branch to _tx_port_svc_handler, with exception stack pointer in r0.
+ #endif
+        );
+}
+
+/* SVC processing is done in C here. */
+void _tx_port_svc_handler (UINT * caller_stack_ptr)
+{
+    UINT  stacked_pc;
+    UINT  stacked_r0;
+    UCHAR svc_number;
+
+    /* Load saved PC from stack. */
+    stacked_pc = caller_stack_ptr[6];
+
+    /* Load SVC number. */
+    svc_number = ((UCHAR *) stacked_pc)[-2];
+
+    switch (svc_number)
+    {
+        case TX_SVC_NUM_SECURE_INIT:
+        {
+            /* Initialize secure stacks for threads calling secure functions. */
+            TZ_InitContextSystem_S();
+
+            break;
+        }
+
+        /* Is it a secure stack allocate request? */
+        case TX_SVC_NUM_SECURE_ALLOC:
+        {
+            /* r0 contains a pointer to the thread control block. */
+            stacked_r0 = caller_stack_ptr[0];
+            TX_THREAD * p_thread = (TX_THREAD *) stacked_r0;
+
+            /* Allocate a secure. The input variable is unused. */
+            p_thread->tx_thread_secure_stack_context = TZ_AllocModuleContext_S(0U);
+
+            /* Convert CMSIS error code to ThreadX error code. */
+            if (0U == p_thread->tx_thread_secure_stack_context)
+            {
+                caller_stack_ptr[0] = TX_NO_MEMORY;
+            }
+            else
+            {
+                caller_stack_ptr[0] = TX_SUCCESS;
+            }
+
+            /* If the context is being allocated for the current thread, load the context. */
+            if (p_thread == _tx_thread_current_ptr)
+            {
+                TZ_LoadContext_S(p_thread->tx_thread_secure_stack_context);
+            }
+
+            break;
+        }
+
+        case TX_SVC_NUM_SECURE_FREE:
+        {
+            /* r0 contains a pointer to the thread control block. */
+            stacked_r0 = caller_stack_ptr[0];
+            TX_THREAD * p_thread = (TX_THREAD *) stacked_r0;
+
+            /* Free the secure context. */
+            uint32_t tz_return_code = TZ_FreeModuleContext_S(p_thread->tx_thread_secure_stack_context);
+
+            /* Convert CMSIS error code to ThreadX error code. */
+            if (0U == tz_return_code)
+            {
+                caller_stack_ptr[0] = TX_THREAD_ERROR;
+            }
+            else
+            {
+                caller_stack_ptr[0] = TX_SUCCESS;
+            }
+
+            break;
+        }
+
+        default:
+        {
+            /* Unknown SVC argument - just return. */
+        }
+    }
+}
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_secure_stack_initialize                Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function initializes the TrustZone secure module.              */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    SVC 3                                                               */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    _tx_initialize_kernel_enter                                         */
+/*                                                                        */
+/**************************************************************************/
+void _tx_thread_secure_stack_initialize (void)
+{
+    __asm volatile (
+        TX_ENABLE_ASM                  // Enable interrupts for SVC call
+        "SVC     %[svc_num]                  \n"
+        TX_RESTORE_ASM                 // Restore interrupt state
+        ::[svc_num] "i" (TX_SVC_NUM_SECURE_INIT) : "memory");
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_thread_secure_stack_allocate.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_secure_stack_allocate.c
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+#include "tx_api.h"
+#include "tx_secure_interface.h"
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_secure_stack_allocate                  Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function enters the SVC handler to allocate a secure stack.    */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    thread_ptr                            Thread control block pointer  */
+/*    stack_size                            Size of secure stack to       */
+/*                                            allocate                    */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    status                                Actual completion status      */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    SVC 1                                                               */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT _tx_thread_secure_stack_allocate (TX_THREAD * thread_ptr, ULONG stack_size)
+{
+    (void) thread_ptr;
+    (void) stack_size;
+
+    UINT return_code;
+
+    /* thread_ptr is used in SVC.  Use inline assembly to ensure it is not clobbered. */
+    __asm volatile (
+        TX_ENABLE_ASM                  // Enable interrupts for SVC call
+        "SVC     %[svc_num]                  \n"
+        TX_RESTORE_ASM                 // Restore interrupt state
+        "MOV  %[ret], r0                     \n"
+        :[ret] "=r" (return_code) :[svc_num] "i" (TX_SVC_NUM_SECURE_ALLOC) : "memory");
+
+    return return_code;
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_thread_secure_stack_free.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_secure_stack_free.c
@@ -1,0 +1,73 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+
+#include "tx_api.h"
+#include "tx_secure_interface.h"
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_secure_stack_free                      Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function enters the SVC handler to free a secure stack.        */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    thread_ptr                            Thread control block pointer  */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    status                                Actual completion status      */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    SVC 2                                                               */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT _tx_thread_secure_stack_free (TX_THREAD * thread_ptr)
+{
+    (void) thread_ptr;
+
+    UINT return_code;
+
+    /* thread_ptr is used in SVC.  Use inline assembly to ensure it is not clobbered. */
+    __asm volatile (
+        TX_ENABLE_ASM                  // Enable interrupts for SVC call
+        "SVC     %[svc_num]                  \n"
+        TX_RESTORE_ASM                 // Restore interrupt state
+        "MOV  %[ret], r0                     \n"
+        :[ret] "=r" (return_code) :[svc_num] "i" (TX_SVC_NUM_SECURE_FREE) : "memory");
+
+    return return_code;
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/tx_thread_stack_build.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_stack_build.c
@@ -1,0 +1,135 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_thread.h"
+
+#define TX_ALIGN_8         (0xFFFFFFF8)
+
+#define TX_INITIAL_IPSR    (0x01000000)
+
+#ifdef TX_SINGLE_MODE_SECURE
+
+/* Build initial LR value for secure mode. */
+ #define TX_INITIAL_LR     (0xFFFFFFFD)
+#else
+
+/* Build initial LR value to return to non-secure PSP. */
+ #define TX_INITIAL_LR     (0xFFFFFFBC)
+#endif
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_stack_build                            Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function builds a stack frame on the supplied thread's stack.  */
+/*    The stack frame results in a fake interrupt return to the supplied  */
+/*    function pointer.                                                   */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    thread_ptr                            Pointer to thread control blk */
+/*    function_ptr                          Pointer to return function    */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    _tx_thread_create                     Create thread service         */
+/*                                                                        */
+/**************************************************************************/
+
+VOID _tx_thread_stack_build (TX_THREAD * thread_ptr, VOID (* function_ptr)(VOID))
+{
+    /* Build a fake interrupt frame.  The form of the fake interrupt stack
+     * on the Cortex-M look like the following after it is built:
+     *
+     * Stack Top:
+     *             #if __FPU_USED
+     *                 LR          Interrupted LR (LR at time of PENDSV)
+     *             #endif
+     *                 r4          Initial value for r4
+     *                 r5          Initial value for r5
+     *                 r6          Initial value for r6
+     *                 r7          Initial value for r7
+     *                 r8          Initial value for r8
+     *                 r9          Initial value for r9
+     *                 r10 (sl)    Initial value for r10 (sl)
+     *                 r11         Initial value for r11
+     *                 r0          Initial value for r0    (Hardware stack starts here!!)
+     *                 r1          Initial value for r1
+     *                 r2          Initial value for r2
+     *                 r3          Initial value for r3
+     *                 r12         Initial value for r12
+     *                 lr          Initial value for lr
+     *                 pc          Initial value for pc
+     *                 xPSR        Initial value for xPSR
+     *
+     * Stack Bottom: (higher memory address) */
+
+    /* First, subtract stack frame size (16 4-byte registers). */
+    UINT * tx_thread_stack_ptr = (UINT *) thread_ptr->tx_thread_stack_end - 16;
+
+#if __FPU_USED
+
+    /* Allocate another word for interrupted LR. */
+    tx_thread_stack_ptr--;
+#endif
+
+    /* Align stack frame to an 8 byte address. */
+    tx_thread_stack_ptr             = (UINT *) ((UINT) tx_thread_stack_ptr & TX_ALIGN_8);
+    thread_ptr->tx_thread_stack_ptr = tx_thread_stack_ptr;
+
+#if __FPU_USED
+
+    /* Default value that will be restored into LR first time thread is restored
+     * from context. */
+    tx_thread_stack_ptr[0] = TX_INITIAL_LR;
+    tx_thread_stack_ptr++;
+#endif
+
+    /* Clear the first 13 registers on the exception stack frame (r4-r11, r0-r3, r12). */
+    memset(tx_thread_stack_ptr, 0U, 13 * sizeof(UINT));
+
+    /* Poison EXC_RETURN value. Set LR to 0xFFFFFFFF. */
+    tx_thread_stack_ptr[13] = UINT32_MAX;
+
+    /* Store initial PC. */
+    tx_thread_stack_ptr[14] = (UINT) function_ptr;
+
+    /* Only T-bit needs be set. */
+    tx_thread_stack_ptr[15] = TX_INITIAL_IPSR;
+}

--- a/ports/cortex_m_cmsis/src/tx_thread_system_return.c
+++ b/ports/cortex_m_cmsis/src/tx_thread_system_return.c
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+#ifdef TX_DISABLE_INLINE
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_thread.h"
+#include "tx_timer.h"
+#include "bsp_api.h"
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_system_return                          Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function is target processor specific.  It is used to transfer */
+/*    control from a thread back to the ThreadX system.  Only a           */
+/*    minimal context is saved since the compiler assumes temp registers  */
+/*    are going to get slicked by a function call anyway.                 */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_thread_schedule                   Thread scheduling loop        */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    ThreadX components                                                  */
+/*                                                                        */
+/**************************************************************************/
+VOID _tx_thread_system_return (VOID)
+{
+    /* Return to real scheduler via PendSV. Note that this routine is often
+     * replaced with in-line assembly in tx_port.h to improved performance.  */
+
+    /* Set PENDSVBIT in ICSR */
+    SCB->ICSR = (uint32_t) SCB_ICSR_PENDSVSET_Msk;
+
+    /* If a thread is returning, briefly enable and restore interrupts. */
+    if (__get_IPSR() == 0)
+    {
+        UINT int_posture;
+#ifdef TX_PORT_USE_BASEPRI
+        int_posture = __get_BASEPRI();
+        __set_BASEPRI(0U);
+        __set_BASEPRI(int_posture);
+#else
+        int_posture = __get_PRIMASK();
+        __enable_irq();
+        __set_PRIMASK(int_posture);
+#endif
+    }
+}
+
+#endif                                 /* TX_DISABLE_INLINE */

--- a/ports/cortex_m_cmsis/src/tx_timer_interrupt.c
+++ b/ports/cortex_m_cmsis/src/tx_timer_interrupt.c
@@ -1,0 +1,137 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Timer                                                               */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_timer.h"
+#include "tx_thread.h"
+
+VOID _tx_timer_interrupt(VOID);
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_timer_interrupt                               Cortex-M/CMSIS    */
+/*                                                                        */
+/*  AUTHOR                                                                */
+/*                                                                        */
+/*    William E. Lamie, Microsoft Corporation                             */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function processes the hardware timer interrupt.  This         */
+/*    processing includes incrementing the system clock and checking for  */
+/*    time slice and/or timer expiration.  If either is found, the        */
+/*    interrupt context save/restore functions are called along with the  */
+/*    expiration functions.                                               */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_timer_expiration_process          Timer expiration processing   */
+/*    _tx_thread_time_slice                 Time slice interrupted thread */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    interrupt vector                                                    */
+/*                                                                        */
+/**************************************************************************/
+VOID _tx_timer_interrupt (VOID)
+{
+    /* Upon entry to this routine, it is assumed that context save has already
+     * been called, and therefore the compiler scratch registers are available
+     * for use.  */
+
+    /* Increment the system clock.  */
+    _tx_timer_system_clock++;
+
+    /* Test for time-slice expiration.  */
+    if (_tx_timer_time_slice)
+    {
+        /* Decrement the time_slice.  */
+        _tx_timer_time_slice--;
+
+        /* Check for expiration.  */
+        if (_tx_timer_time_slice == 0U)
+        {
+            /* Set the time-slice expired flag.  */
+            _tx_timer_expired_time_slice = TX_TRUE;
+        }
+    }
+
+    /* Test for timer expiration.  */
+    if (*_tx_timer_current_ptr)
+    {
+        /* Set expiration flag.  */
+        _tx_timer_expired = TX_TRUE;
+    }
+    else
+    {
+        /* No timer expired, increment the timer pointer.  */
+        _tx_timer_current_ptr++;
+
+        /* Check for wrap-around.  */
+        if (_tx_timer_current_ptr == _tx_timer_list_end)
+        {
+            /* Wrap to beginning of list.  */
+            _tx_timer_current_ptr = _tx_timer_list_start;
+        }
+    }
+
+    /* See if anything has expired.  */
+    if ((_tx_timer_expired_time_slice) || (_tx_timer_expired))
+    {
+        /* Did a timer expire?  */
+        if (_tx_timer_expired)
+        {
+            /* Process timer expiration.  */
+            _tx_timer_expiration_process();
+        }
+
+        /* Did time slice expire?  */
+        if (_tx_timer_expired_time_slice)
+        {
+            /* Time slice interrupted thread.  */
+            _tx_thread_time_slice();
+        }
+    }
+
+    /* See if the current thread needs to be preempted */
+    if ((_tx_thread_execute_ptr) &&
+        (_tx_thread_current_ptr != _tx_thread_execute_ptr) &&
+        (!_tx_thread_preempt_disable))
+    {
+        /* Set PendSV for preemption. */
+        SCB->ICSR = (uint32_t) SCB_ICSR_PENDSVSET_Msk;
+    }
+}

--- a/ports/cortex_m_cmsis/src/txe_thread_secure_stack_allocate.c
+++ b/ports/cortex_m_cmsis/src/txe_thread_secure_stack_allocate.c
@@ -1,0 +1,124 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_initialize.h"
+#include "tx_thread.h"
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _tx_thread_secure_stack_allocate                  Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function checks for errors in the secure stack allocate        */
+/*    function call.                                                      */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    thread_ptr                            Thread control block pointer  */
+/*    stack_size                            Size of secure stack to       */
+/*                                            allocate                    */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    TX_THREAD_ERROR                       Invalid thread pointer        */
+/*    TX_CALLER_ERROR                       Invalid caller of function    */
+/*    status                                Actual completion status      */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_thread_secure_stack_allocate      Actual stack alloc function   */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT    _txe_thread_secure_stack_allocate(TX_THREAD *thread_ptr, ULONG stack_size)
+{
+#if defined(TX_SINGLE_MODE_SECURE) || defined(TX_SINGLE_MODE_NON_SECURE)
+    (void) thread_ptr;
+    (void) stack_size;
+
+    return(TX_FEATURE_NOT_ENABLED);
+#else
+UINT    status;
+    
+    /* Default status to success.  */
+    status =  TX_SUCCESS;
+    
+    /* Check for an invalid thread pointer.  */
+    if (thread_ptr == TX_NULL)
+    {
+
+        /* Thread pointer is invalid, return appropriate error code.  */
+        status =  TX_THREAD_ERROR;
+    }
+
+    /* Now check for invalid thread ID.  */
+    else if (thread_ptr -> tx_thread_id != TX_THREAD_ID)
+    {
+
+        /* Thread pointer is invalid, return appropriate error code.  */
+        status =  TX_THREAD_ERROR;
+    }
+
+    else
+    {
+        /* Do nothing. */
+    }
+    
+    /* Check for interrupt call.  */
+    if (TX_THREAD_GET_SYSTEM_STATE() != ((ULONG) 0))
+    {
+        /* Is call from an interrupt and not initialization?  */
+        if (TX_THREAD_GET_SYSTEM_STATE() < TX_INITIALIZE_IN_PROGRESS)
+        {
+            /* Invalid caller of this function, return appropriate error code.  */
+            status =  TX_CALLER_ERROR;
+        }
+    }
+    
+    /* Determine if everything is okay.  */
+    if (status == TX_SUCCESS)
+    {
+
+        /* Call actual secure stack allocate function.  */
+        status =  _tx_thread_secure_stack_allocate(thread_ptr, stack_size);
+    }
+
+    /* Return completion status.  */
+    return(status);
+#endif
+}
+
+#endif

--- a/ports/cortex_m_cmsis/src/txe_thread_secure_stack_free.c
+++ b/ports/cortex_m_cmsis/src/txe_thread_secure_stack_free.c
@@ -1,0 +1,121 @@
+/**************************************************************************/
+/*                                                                        */
+/*       Copyright (c) Microsoft Corporation. All rights reserved.        */
+/*                                                                        */
+/*       This software is licensed under the Microsoft Software License   */
+/*       Terms for Microsoft Azure RTOS. Full text of the license can be  */
+/*       found in the LICENSE file at https://aka.ms/AzureRTOS_EULA       */
+/*       and in the root directory of this software.                      */
+/*                                                                        */
+/**************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** ThreadX Component                                                     */
+/**                                                                       */
+/**   Thread                                                              */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define TX_SOURCE_CODE
+
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_initialize.h"
+#include "tx_thread.h"
+
+#ifdef TX_PORT_TRUSTZONE_NSC_ENABLE
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _txe_thread_secure_stack_free                     Cortex-M/CMSIS    */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function checks for errors in the secure stack free            */
+/*    function call.                                                      */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    thread_ptr                            Thread control block pointer  */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    TX_THREAD_ERROR                       Invalid thread pointer        */
+/*    TX_CALLER_ERROR                       Invalid caller of function    */
+/*    status                                Actual completion status      */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _tx_thread_secure_stack_free          Actual stack free function    */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application Code                                                    */
+/*                                                                        */
+/**************************************************************************/
+UINT    _txe_thread_secure_stack_free(TX_THREAD *thread_ptr)
+{
+#if defined(TX_SINGLE_MODE_SECURE) || defined(TX_SINGLE_MODE_NON_SECURE)
+    (void) thread_ptr;
+
+    return(TX_FEATURE_NOT_ENABLED);
+#else
+UINT    status;
+    
+    /* Default status to success.  */
+    status =  TX_SUCCESS;
+    
+    /* Check for an invalid thread pointer.  */
+    if (thread_ptr == TX_NULL)
+    {
+
+        /* Thread pointer is invalid, return appropriate error code.  */
+        status =  TX_THREAD_ERROR;
+    }
+
+    /* Now check for invalid thread ID.  */
+    else if (thread_ptr -> tx_thread_id != TX_THREAD_ID)
+    {
+
+        /* Thread pointer is invalid, return appropriate error code.  */
+        status =  TX_THREAD_ERROR;
+    }
+
+    else
+    {
+        /* Do nothing. */
+    }
+    
+    /* Check for interrupt call.  */
+    if (TX_THREAD_GET_SYSTEM_STATE() != ((ULONG) 0))
+    {
+        /* Is call from an interrupt and not initialization?  */
+        if (TX_THREAD_GET_SYSTEM_STATE() < TX_INITIALIZE_IN_PROGRESS)
+        {
+            /* Invalid caller of this function, return appropriate error code.  */
+            status =  TX_CALLER_ERROR;
+        }
+    }
+    
+    /* Determine if everything is okay.  */
+    if (status == TX_SUCCESS)
+    {
+
+        /* Call actual secure stack allocate function.  */
+        status =  _tx_thread_secure_stack_free(thread_ptr);
+    }
+
+    /* Return completion status.  */
+    return(status);
+#endif
+}
+
+#endif


### PR DESCRIPTION
New port files based on ra/microsoft/azure-rtos/threadx/ports/cortex_m33/iar and Renesas RA port.

Major updates from CM33/IAR port include:
 * No assembly files. The port is mostly C, with inline assembly used where necessary.
 * Uses CMSIS core functions where possible.
 * Uses Arm TrustZone RTOS Context Management functions (https://arm-software.github.io/CMSIS_5/Core/html/group__context__trustzone__functions.html).
 * Supports Cortex-M33, Cortex-M23, and Cortex-M4 in a single code base.
 * Supports GCC (9-2019-q4-major), IAR (8.50.7), and Arm Compiler 6 (6.14) in a single code base.