### PR TITLE
Add thread local storage option

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -89,6 +89,8 @@ target_sources(${PROJECT_NAME}
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_identify.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_info_get.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_initialize.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_local_storage_get.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_local_storage_set.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_performance_info_get.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_performance_system_info_get.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_preemption_change.c

--- a/common/inc/tx_api.h
+++ b/common/inc/tx_api.h
@@ -336,6 +336,10 @@ typedef struct TX_TIMER_STRUCT
 
 } TX_TIMER;
 
+#ifndef TX_THREAD_LOCAL_STORAGE_SLOTS
+#define TX_THREAD_LOCAL_STORAGE_SLOTS 0
+#endif
+
 
 /* ThreadX thread control block structure follows.  Additional fields
    can be added providing they are added after the information that is
@@ -471,6 +475,10 @@ typedef struct TX_THREAD_STRUCT
     /* Define the total number of times this thread had suspension lifted
        because of the tx_thread_wait_abort service.  */
     ULONG               tx_thread_performance_wait_abort_count;
+#endif
+
+#if TX_THREAD_LOCAL_STORAGE_SLOTS > 0
+    VOID                *tx_thread_local_storage_pointers[ TX_THREAD_LOCAL_STORAGE_SLOTS ];
 #endif
 
     /* Define the highest stack pointer variable.  */
@@ -1060,6 +1068,8 @@ UINT    _tx_trace_interrupt_control(UINT new_posture);
 #define tx_thread_terminate                         _tx_thread_terminate
 #define tx_thread_time_slice_change                 _tx_thread_time_slice_change
 #define tx_thread_wait_abort                        _tx_thread_wait_abort
+#define tx_thread_local_storage_get                 _tx_thread_local_storage_get
+#define tx_thread_local_storage_set                 _tx_thread_local_storage_set
 
 #define tx_time_get                                 _tx_time_get
 #define tx_time_set                                 _tx_time_set
@@ -1184,6 +1194,9 @@ UINT    _tx_trace_interrupt_control(UINT new_posture);
 #define tx_thread_terminate                         _txr_thread_terminate
 #define tx_thread_time_slice_change                 _txr_thread_time_slice_change
 #define tx_thread_wait_abort                        _txr_thread_wait_abort
+#define tx_thread_local_storage_get                 _tx_thread_local_storage_get
+#define tx_thread_local_storage_set                 _tx_thread_local_storage_set
+
 
 #define tx_time_get                                 _tx_time_get
 #define tx_time_set                                 _tx_time_set
@@ -1295,6 +1308,9 @@ UINT    _tx_el_interrupt_control(UINT new_posture);
 #define tx_thread_terminate                         _txe_thread_terminate
 #define tx_thread_time_slice_change                 _txe_thread_time_slice_change
 #define tx_thread_wait_abort                        _txe_thread_wait_abort
+#define tx_thread_local_storage_get                 _tx_thread_local_storage_get
+#define tx_thread_local_storage_set                 _tx_thread_local_storage_set
+
 
 #define tx_time_get                                 _tx_time_get
 #define tx_time_set                                 _tx_time_set
@@ -1634,6 +1650,8 @@ UINT        _tx_thread_suspend(TX_THREAD *thread_ptr);
 UINT        _tx_thread_terminate(TX_THREAD *thread_ptr);
 UINT        _tx_thread_time_slice_change(TX_THREAD *thread_ptr, ULONG new_time_slice, ULONG *old_time_slice);
 UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
+VOID       *_tx_thread_local_storage_get(TX_THREAD* thread_ptr, UINT index);
+UINT        _tx_thread_local_storage_set(TX_THREAD* thread_ptr, UINT index, VOID* value);
 
 
 /* Define error checking shells for API services.  These are only referenced by the 

--- a/common/inc/tx_thread.h
+++ b/common/inc/tx_thread.h
@@ -268,6 +268,11 @@
 #define TX_THREAD_CREATE_INTERNAL_EXTENSION(t)
 #endif
 
+/* Define default number of local storage slots to be 0, if it hasn't been defined previously (typically in tx_port.h).  */
+#ifndef TX_THREAD_LOCAL_STORAGE_SLOTS
+#define TX_THREAD_LOCAL_STORAGE_SLOTS 0
+#endif
+
 
 /* Define internal thread control function prototypes.  */
 
@@ -286,6 +291,8 @@ VOID        _tx_thread_system_suspend(TX_THREAD *thread_ptr);
 VOID        _tx_thread_system_ni_suspend(TX_THREAD *thread_ptr, ULONG wait_option);
 VOID        _tx_thread_time_slice(VOID);
 VOID        _tx_thread_timeout(ULONG timeout_input);
+VOID       *_tx_thread_local_storage_get(TX_THREAD *thread_ptr, UINT index);
+UINT        _tx_thread_local_storage_set(TX_THREAD *thread_ptr, UINT index, VOID* value);
 
 
 /* Thread control component data declarations follow.  */

--- a/common/src/tx_thread_local_storage_get.c
+++ b/common/src/tx_thread_local_storage_get.c
@@ -26,82 +26,81 @@
 /* Include necessary system files.  */
 
 #include "tx_api.h"
-#include "tx_thread.h"
-#ifdef TX_ENABLE_EVENT_TRACE
 #include "tx_trace.h"
+#include "tx_thread.h"
+
+#ifndef TX_THREAD_LOCAL_STORAGE_SLOTS
+#define TX_THREAD_LOCAL_STORAGE_SLOTS 0
 #endif
 
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
-/*    _tx_thread_identify                                 PORTABLE C      */
+/*    _tx_thread_local_storage_get                        PORTABLE C      */
 /*                                                           6.1          */
 /*  AUTHOR                                                                */
 /*                                                                        */
-/*    William E. Lamie, Microsoft Corporation                             */
+/*    Alex Earl                                                           */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function returns the control block pointer of the currently    */
-/*    executing thread.  If the return value is NULL, no thread is        */
-/*    executing.                                                          */
+/*    This function retrieves the value of a thread local variable if it  */
+/*    exists.                                                             */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */
-/*    None                                                                */
+/*    thread_ptr                            Thread control block pointer  */
+/*    index                                 Index of thread local data    */
 /*                                                                        */
 /*  OUTPUT                                                                */
 /*                                                                        */
-/*    TX_THREAD *                           Pointer to control block of   */
-/*                                            currently executing thread  */
+/*    data pointer                          Pointer to data, or NULL if   */
+/*                                          index exists                  */
 /*                                                                        */
 /*  CALLS                                                                 */
-/*                                                                        */
-/*    None                                                                */
+/*  _tx_thread_identify                                                   */
 /*                                                                        */
 /*  CALLED BY                                                             */
-/*                                                                        */
-/*    Application Code                                                    */
-/*    _tx_thread_local_storage_get                                        */
-/*    _tx_thread_local_storage_set                                        */
+/*  Application code                                                      */
 /*                                                                        */
 /*  RELEASE HISTORY                                                       */
 /*                                                                        */
 /*    DATE              NAME                      DESCRIPTION             */
 /*                                                                        */
-/*  05-19-2020     William E. Lamie         Initial Version 6.0           */
-/*  09-30-2020     Yuxin Zhou               Modified comment(s),          */
-/*                                            resulting in version 6.1    */
+/*  01-27-2021     Alex Earl                Initial Version 6.0           */
 /*                                                                        */
 /**************************************************************************/
-TX_THREAD  *_tx_thread_identify(VOID)
+VOID *_tx_thread_local_storage_get(TX_THREAD *thread_ptr, UINT index)
 {
+VOID       *result = NULL;
 
-TX_THREAD       *thread_ptr;
+    #if TX_THREAD_LOCAL_STORAGE_SLOTS > 0
+    if(index < TX_THREAD_LOCAL_STORAGE_SLOTS)
+    {
 
-TX_INTERRUPT_SAVE_AREA
+        /* Check if we need to get the current thread pointer */
+        if(NULL == thread_ptr)
+        {
 
-    
-    /* Disable interrupts to put the timer on the created list.  */
-    TX_DISABLE
+            /* Retrieve the current thread pointer */
+            thread_ptr = _tx_thread_identify();
+        }
 
-#ifdef TX_ENABLE_EVENT_TRACE
+        if(NULL != thread_ptr)
+        {
 
-    /* If trace is enabled, insert this event into the trace buffer.  */
-    TX_TRACE_IN_LINE_INSERT(TX_TRACE_THREAD_IDENTIFY, 0, 0, 0, 0, TX_TRACE_THREAD_EVENTS)
-#endif
+            /* If we have a thread pointer, retrieve the data from the index location */
+            result = thread_ptr->tx_thread_local_storage_pointers[index];
+        }
+        else
+        {
 
-   /* Log this kernel call.  */
-    TX_EL_THREAD_IDENTIFY_INSERT
+            /* return NULL since the thread pointer doesn't exist */
+            result = NULL;
+        }
+    }
+    #endif
 
-    /* Pickup thread pointer.  */
-    TX_THREAD_GET_CURRENT(thread_ptr)
-
-    /* Restore interrupts.  */
-    TX_RESTORE
-
-    /* Return the current thread pointer.  */
-    return(thread_ptr);
+    return(result);
 }
-

--- a/ports/win32/vs_2019/example_build/tx/tx.vcxproj
+++ b/ports/win32/vs_2019/example_build/tx/tx.vcxproj
@@ -167,6 +167,8 @@
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_identify.c" />
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_info_get.c" />
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_initialize.c" />
+    <ClCompile Include="..\..\..\..\..\common\src\tx_thread_local_storage_get.c" />
+    <ClCompile Include="..\..\..\..\..\common\src\tx_thread_local_storage_set.c" />
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_performance_info_get.c" />
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_performance_system_info_get.c" />
     <ClCompile Include="..\..\..\..\..\common\src\tx_thread_preemption_change.c" />


### PR DESCRIPTION
This adds the possibility of having thread local storage items in the thread context structure. By default, the number of slots is 0, so no extra space is taken up by the current configs. If the tx_port.h sets TX_THREAD_LOCAL_STORAGE_SLOTS to a number > 0, then that number of slots will be available for use with the functions provided. This is an opt-in feature.