### PR TITLE
Enable Arm Cortex-M33 Support

### DIFF
--- a/cmake/arm-none-eabi.cmake
+++ b/cmake/arm-none-eabi.cmake
@@ -17,7 +17,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set(CMAKE_C_FLAGS   "${MCPU_FLAGS} ${VFP_FLAGS} ${SPEC_FLAGS} -fdata-sections -ffunction-sections -mlong-calls" CACHE INTERNAL "c compiler flags")
 set(CMAKE_CXX_FLAGS "${MCPU_FLAGS} ${VFP_FLAGS} -fdata-sections -ffunction-sections -fno-rtti -fno-exceptions -mlong-calls" CACHE INTERNAL "cxx compiler flags")
-set(CMAKE_ASM_FLAGS "${MCPU_FLAGS} -x assembler-with-cpp" CACHE INTERNAL "asm compiler flags")
+set(CMAKE_ASM_FLAGS "${MCPU_FLAGS} ${VFP_FLAGS} -x assembler-with-cpp" CACHE INTERNAL "asm compiler flags")
 set(CMAKE_EXE_LINKER_FLAGS "${MCPU_FLAGS} ${LD_FLAGS} -Wl,--gc-sections" CACHE INTERNAL "exe link flags")
 
 SET(CMAKE_C_FLAGS_DEBUG "-Og -g -ggdb3" CACHE INTERNAL "c debug compiler flags")

--- a/cmake/cortex_m33.cmake
+++ b/cmake/cortex_m33.cmake
@@ -1,0 +1,14 @@
+
+# Name of the target
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR cortex-m33)
+
+set(THREADX_ARCH "cortex_m33")
+set(THREADX_TOOLCHAIN "gnu")
+
+set(MCPU_FLAGS "-mthumb -mcpu=cortex-m33+nodsp+nofp")
+set(VFP_FLAGS "-mfloat-abi=softfp")
+set(SPEC_FLAGS "--specs=nosys.specs")
+# set(LD_FLAGS "-nostartfiles")
+
+include(${CMAKE_CURRENT_LIST_DIR}/arm-none-eabi.cmake)

--- a/ports/cortex_m33/gnu/CMakeLists.txt
+++ b/ports/cortex_m33/gnu/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+target_sources(${PROJECT_NAME} PRIVATE
+    # {{BEGIN_TARGET_SOURCES}}
+	${CMAKE_CURRENT_LIST_DIR}/src/txe_thread_secure_stack_allocate.c
+	${CMAKE_CURRENT_LIST_DIR}/src/txe_thread_secure_stack_free.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_initialize_low_level.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_context_restore.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_context_save.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_interrupt_control.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_interrupt_disable.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_interrupt_restore.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_schedule.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_secure_stack.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_secure_stack_allocate.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_secure_stack_free.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_build.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_error_handler.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_error_notify.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_system_return.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
+    # {{END_TARGET_SOURCES}}
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/inc
+)

--- a/ports/cortex_m33/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_m33/gnu/src/tx_thread_schedule.S
@@ -345,6 +345,8 @@ _tx_svc_secure_init:
     .thumb_func
 .type _tx_vfp_access, function
 _tx_vfp_access:
+#if TX_ENABLE_FPU_SUPPORT
     VMOV.F32 s0, s0                                 // Simply access the VFP
+#endif
     BX       lr                                     // Return to caller
 .end


### PR DESCRIPTION
This commit enables support for the Arm Cortex-M33, using the GNU toolchain. By default, HW DSP or FP support has been disabled, and compilation takes place with `-mfloat-abi=softfp`.

It also address an issue with `tx_thread_schedule.S` where floating point instructions were being hard-coded into the assembly code, causing a fault on devices that don't have HW FPU support, such as the MPS3 AN524 Core 0, etc.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>
Signed-off-by: Jimmy Brisson <jimmy.brisson@linaro.org>