### PR TITLE
Support for CMake compilation for Cortex M33

### DIFF
--- a/ports/cortex_m33/gnu/CMakeLists.txt
+++ b/ports/cortex_m33/gnu/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+target_sources(${PROJECT_NAME} PRIVATE
+    # {{BEGIN_TARGET_SOURCES}}
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_context_restore.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_context_save.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_interrupt_control.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_schedule.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_build.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_system_return.S
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
+    # {{END_TARGET_SOURCES}}
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/inc
+)


### PR DESCRIPTION
The CMakeLists.txt file has been included to support compilation
with CMake for Cortex M33. It has been entirely based on Cortex M4
compilation system. It has been tested and worked for STM32U575
device.

Signed-off-by: Asier Llano <allano@hubbell.com>