### PR TITLE
Export _tx_handler_svc_unrecognized as weak symbol.

### DIFF
--- a/ports_module/cortex_a7/ac5/module_manager/src/tx_thread_schedule.s
+++ b/ports_module/cortex_a7/ac5/module_manager/src/tx_thread_schedule.s
@@ -157,6 +157,7 @@ __tx_swi_interrupt
 ; Unknown SVC argument
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Unrecognized service call
+    EXPORT _tx_handler_svc_unrecognized [WEAK]
 _tx_handler_svc_unrecognized
 
 _tx_handler_svc_unrecognized_loop           ; We should never get here

--- a/ports_module/cortex_a7/gnu/module_manager/src/tx_thread_schedule.s
+++ b/ports_module/cortex_a7/gnu/module_manager/src/tx_thread_schedule.s
@@ -143,6 +143,7 @@ __tx_swi_interrupt:
 // Unknown SVC argument
 /////////////////////////////////////////////////////////////////////
     // Unrecognized service call
+    .weak _tx_handler_svc_unrecognized
 _tx_handler_svc_unrecognized:
 
 _tx_handler_svc_unrecognized_loop:          // We should never get here

--- a/ports_module/cortex_a7/iar/module_manager/src/tx_thread_schedule.s
+++ b/ports_module/cortex_a7/iar/module_manager/src/tx_thread_schedule.s
@@ -150,6 +150,7 @@ SWI_Handler
 ; Unknown SVC argument
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Unrecognized service call
+    PUBWEAK _tx_handler_svc_unrecognized
 _tx_handler_svc_unrecognized
 
 _tx_handler_svc_unrecognized_loop           ; We should never get here

--- a/ports_module/cortex_r4/ac6/module_manager/src/tx_thread_schedule.S
+++ b/ports_module/cortex_r4/ac6/module_manager/src/tx_thread_schedule.S
@@ -147,6 +147,7 @@ __tx_svc_interrupt:
 /* Unknown SVC argument                                                   */
 /**************************************************************************/
     /* Unrecognized service call */
+    .weak _tx_handler_svc_unrecognized
 _tx_handler_svc_unrecognized:
 
 _tx_handler_svc_unrecognized_loop:           /* We should never get here */

--- a/ports_module/cortex_r4/iar/module_manager/src/tx_thread_schedule.s
+++ b/ports_module/cortex_r4/iar/module_manager/src/tx_thread_schedule.s
@@ -140,6 +140,7 @@ SWI_Handler
 ; Unknown SVC argument
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Unrecognized service call
+    PUBWEAK _tx_handler_svc_unrecognized
 _tx_handler_svc_unrecognized
 
 _tx_handler_svc_unrecognized_loop               ; We should never get here


### PR DESCRIPTION
Export _tx_handler_svc_unrecognized as weak symbol, applications can implement customized function to handle other SVCs.