### PR TITLE
cortex_a55_smp/gnu: added barrier instruction before setting tx_thread_smp_lock_ready_bit 

### DIFF
--- a/ports_smp/cortex_a55_smp/gnu/src/tx_thread_context_restore.S
+++ b/ports_smp/cortex_a55_smp/gnu/src/tx_thread_context_restore.S
@@ -289,6 +289,7 @@ __tx_thread_dont_save_ts:
 
     /* Set bit indicating this thread is ready for execution.  */
 
+    DMB     ISH                                 // Ensure that all accesses to shared resources have completed
     MOV     x2, #1                              // Build ready flag
     STR     w2, [x0, #260]                      // Set thread's ready flag
     DMB     ISH                                 // Ensure that accesses to shared resource have completed

--- a/ports_smp/cortex_a55_smp/gnu/src/tx_thread_system_return.S
+++ b/ports_smp/cortex_a55_smp/gnu/src/tx_thread_system_return.S
@@ -168,6 +168,7 @@ __tx_thread_dont_save_ts:
 
     /* Set ready bit in thread control block.  */
 
+    DMB     ISH                                 // Ensure that all accesses to shared resources have completed
     MOV     x3, #1                              // Build ready value
     STR     w3, [x6, #260]                      // Make the thread ready
     DMB     ISH                                 //


### PR DESCRIPTION
Added barrier instruction before setting tx_thread_smp_lock_ready_bit  in _tx_thread_context_restore() and _tx_thread_system_return() to ensure accesses to shared resources have completed. This ensures that _tx_thread_schedule() reads correct thread data when it sees tx_thread_smp_lock_ready_bit set. This update should be relevant for other Cortex-A SMP ports as well. However, the update has been tested only on the Cortex-A55 platform.